### PR TITLE
Use bikeshed's syntax highlighting throughout.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -78,7 +78,7 @@ strategies to ossify, preventing improvement in one of the most dynamic areas of
 virtual machine technology.
 
 In particular, this means that you can't expose any API that acts as a weak reference, e.g. with a
-property that becomes <code>null</code> once garbage collection runs. Such freeing of memory must
+property that becomes <code highlight="js">null</code> once garbage collection runs. Such freeing of memory must
 be entirely deterministic.
 
 <div class="note">
@@ -120,13 +120,13 @@ much like a data property as possible. Specific guidance in this regard includes
 
 * Getters must not have any (observable) side effects.
 * Getters should not perform any expensive operations. (A notable failure of the platform in this
-    regard is getters like <code>offsetTop</code> performing layout; do not repeat this mistake.)
+    regard is getters like <code highlight="js">offsetTop</code> performing layout; do not repeat this mistake.)
 * Ensure that your attribute's getter returns the same object each time it is called, until some
     occurrence in another part of the system causes a logical "reset" of the property's value. In
-    particular, <code>obj.attribute === obj.attribute</code> must always hold, and so returning a
+    particular, <code highlight="js">obj.attribute === obj.attribute</code> must always hold, and so returning a
     new value from the getter each time is not allowed.
 * Whenever possible, preserve values given to the setter for return from the getter. That is,
-    given <code>obj.attribute = x</code>, a subsequent <code>obj.attribute === x</code> should be
+    given <code highlight="js">obj.attribute = x</code>, a subsequent <code highlight="js">obj.attribute === x</code> should be
     true. (This will not always be the case, e.g. if a normalization or type conversion step is
     necessary, but should be held as a goal for normal code paths.)
 
@@ -146,39 +146,39 @@ design, the following rules have emerged:
     <tr>
         <th>Methods and properties</th>
         <td>Camel case</td>
-        <td><code>document.createAttribute()</code><br>
-            <code>document.compatMode</code></td>
+        <td><code highlight="js">document.createAttribute()</code><br>
+            <code highlight="js">document.compatMode</code></td>
     </tr>
     <tr>
         <th>Classes and mixins</th>
         <td>Pascal case</td>
-        <td><code>NamedNodeMap</code><br>
-            <code>NonElementParentNode</code></td>
+        <td><code highlight="js">NamedNodeMap</code><br>
+            <code highlight="js">NonElementParentNode</code></td>
     </tr>
     <tr>
         <th>Initialisms in APIs</th>
         <td>All caps, except when the first word in a method or property</td>
-        <td><code>HTMLCollection</code><br>
-            <code>element.innerHTML</code><br>
-            <code>document.bgColor</code></td>
+        <td><code highlight="js">HTMLCollection</code><br>
+            <code highlight="js">element.innerHTML</code><br>
+            <code highlight="js">document.bgColor</code></td>
     </tr>
     <tr>
         <th>Repeated initialisms in APIs</th>
         <td>Follow the same rule</td>
-        <td><code>HTMLHRElement</code><br>
-            <code>RTCDTMFSender</code><br>
+        <td><code highlight="js">HTMLHRElement</code><br>
+            <code highlight="js">RTCDTMFSender</code><br>
     </tr>
     <tr>
         <th>The abbreviation of "identity"</th>
-        <td><code>Id</code>, except when the first word in a method or property</td>
-        <td><code>node.getElementById()</code><br>
-            <code>event.pointerId</code><br>
-            <code>credential.id</code></td>
+        <td><code highlight="js">Id</code>, except when the first word in a method or property</td>
+        <td><code highlight="js">node.getElementById()</code><br>
+            <code highlight="js">event.pointerId</code><br>
+            <code highlight="js">credential.id</code></td>
     </tr>
     <tr>
         <th>Enumeration values</th>
         <td>Lowercase, dash-delimited</td>
-        <td><code>"no-referrer-when-downgrade"</code></td>
+        <td><code highlight="js">"no-referrer-when-downgrade"</code></td>
     </tr>
     <tr>
         <th>Events</th>
@@ -189,27 +189,27 @@ design, the following rules have emerged:
     <tr>
         <th>HTML elements and attributes</th>
         <td>Lowercase, concatenated</td>
-        <td><code>&lt;figcaption&gt;</code><br>
-            <code>&lt;textarea maxlength&gt;</code></td>
+        <td><code highlight="html">&lt;figcaption&gt;</code><br>
+            <code highlight="html">&lt;textarea maxlength&gt;</code></td>
     </tr>
     <tr>
         <th>JSON keys</th>
         <td>Lowercase, underscore-delimited</td>
-        <td><code>manifest.short_name</code></td>
+        <td><code highlight="js">manifest.short_name</code></td>
     </tr>
 </table>
 
 <div class="note">
 Note that in particular, when a HTML attribute is <a>reflected</a> as a property, the attribute
 and property's casings will not necessarily match. For example, the HTML attribute
-<code>novalidate</code> on <code>&lt;form&gt;</code> is <a>reflected</a> as the
-<code>noValidate</code> property on <code>HTMLFormElement</code>.
+<code>novalidate</code> on <code highlight="html">&lt;form&gt;</code> is <a>reflected</a> as the
+<code highlight="js">noValidate</code> property on <code highlight="js">HTMLFormElement</code>.
 </div>
 
 <div class="note">
 Repeated initialisms are particularly non-uniform throughout the platform. Infamous historical
-examples that violate the above rules are <code>XMLHttpRequest</code> and
-<code>HTMLHtmlElement</code>. Do not follow their example; instead always capitalize your
+examples that violate the above rules are <code highlight="js">XMLHttpRequest</code> and
+<code highlight="js">HTMLHtmlElement</code>. Do not follow their example; instead always capitalize your
 initialisms, even if they are repeated.
 </div>
 
@@ -297,12 +297,12 @@ Instead, you probably want to stick with one of:
   :: Any JavaScript number excluding infinities and NaN
 
   : <code>[EnforceRange] long long</code>
-  :: Any JavaScript number in the integer-representable range, throwing a <code>TypeError</code>
+  :: Any JavaScript number in the integer-representable range, throwing a <code highlight="js">TypeError</code>
       outside the range and rounding inside of it
 
   : <code>[EnforceRange] unsigned long long</code>
   :: Any nonnegative JavaScript number in the integer-representable range, throwing a
-      <code>TypeError</code> outside the range and rounding inside of it
+      <code highlight="js">TypeError</code> outside the range and rounding inside of it
 
 Additionally, you can combine any of the above with an extra line in your algorithm to validate
 that the number is within the expected domain-specific range, and throwing or performing other
@@ -311,7 +311,7 @@ modulo 65535, it might be appropriate to take it modulo 360, for example.)
 
 A special case of domain-specific validation, which Web IDL already has you covered for, is the
 0–255 range. This can be written as <code>[EnforcedRange] octet</code>: any JavaScript number in
-the range 0–255, throwing a <code>TypeError</code> outside the range and rounding inside of it.
+the range 0–255, throwing a <code highlight="js">TypeError</code> outside the range and rounding inside of it.
 (And indeed, if it turns out that the other power-of-two ranges are semantically meaningful for
 your domain, such that you want the modulo or range-checking behavior, feel free to use them.)
 
@@ -324,7 +324,7 @@ not 64.
 <h3 id="milliseconds">Use milliseconds for time measurement</h3>
 
 Any web API that accepts a time measurement should do so in milliseconds. This is a tradition
-stemming from <code>setTimeout</code> and the <code>Date</code> API, and carried through since
+stemming from <code highlight="js">setTimeout</code> and the <code highlight="js">Date</code> API, and carried through since
 then.
 
 Even if seconds (or some other unit) are more natural in the domain of an API, sticking with
@@ -339,12 +339,12 @@ nanoseconds.
 When representing date-times on the platform, use the {{DOMTimeStamp}} type, with values being the
  number of milliseconds relative to 1970-01-01T00:00:00Z.
 
-The JavaScript <code>Date</code> class must not be used for this purpose. <code>Date</code> objects
+The JavaScript <code highlight="js">Date</code> class must not be used for this purpose. <code highlight="js">Date</code> objects
 are mutable (and there is no way to make them immutable), which comes with a host of attendant
 problems.
 
 <div class="note">
-    For more background on why <code>Date</code> must not be used, see the following:
+    For more background on why <code highlight="js">Date</code> must not be used, see the following:
 
     * <a href="https://esdiscuss.org/topic/frozen-date-objects">Frozen date objects?</a> on
         es-discuss


### PR DESCRIPTION
Set the default highlight language to js, remove some use of explicit highlight="js", and add markup to annotate the things that are not JS (because they're HTML, WebIDL, or event names).

Note that it would be possible to go in the other direction and use highlight="js" everywhere.  The editing errors resulting from that are a little less serious (no highlight rather than incorrect highlight), perhaps, but it's a decent amount more markup.