### PR TITLE
Suggest use of promises, and point to promises-guide.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -315,6 +315,33 @@ For example,
 is more readable than
 <code highlight="js">window.scrollBy(50, 0)</code>.
 
+<h3 id="promises">Design asynchronous APIs using Promises</h3>
+
+Asynchronous APIs should generally be designed using promises
+rather than callback functions.
+This is the pattern that we've settled on for the Web platform,
+and having APIs consistently use promises means that the APIs are
+easier to use together (such as by chaining promises).
+This pattern also tends to produce cleaner code than the use
+of APIs with callback functions.
+
+Furthermore, you should carefully consider whether an API might need
+to be asynchronous before making it a synchronous API.
+An API might need to be asynchronous if:
+  * some implementations may (in at least some cases) wish to prompt the user
+    or ask the user for permission before allowing use of the API,
+  * implementations may need to consider information that might be stored
+    on disk in order to compute the result,
+  * implementations may need to interact with the network before returning
+    the result, or
+  * implementations may wish to do work on another thread or in another
+    process before returning the result.
+
+For more information on how to design APIs using promises,
+and on when to use promises and when not to use promises,
+see <strong><a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing
+Promise-Using Specifications</a></strong>.
+
 <h2 id="event-design">Event Design</h2>
 
 <h3 id="always-add-event-handlers">Always add event handler attributes</h3>


### PR DESCRIPTION
In discussion before dinner we realized that the design-principles document didn't point to the promises-guide.  This adds a brief section on when promises may be needed, and then points to the promises guide for more.