### PR TITLE
Improve wording around time vs. timestamps being monotonically increasing.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -461,11 +461,17 @@ problems.
         on the Web IDL Bugzilla
 </div>
 
-However, date-times are not monotonically increasing; subsequent values may either decrease or
-remain the same. The limitation to millisecond resolution can also be constraining. Thus, for time
-stamps that do not need to correspond to an absolute time, consider using {{DOMHighResTimeStamp}},
-which provides monotonically increasing sub-millisecond timestamps that are comparable within a
-single <a>browsing context</a> or web worker. See [[!HIGHRES-TIME]] for more details.
+While in theory time is monotonically increasing,
+values like {{DOMTimeStamp}} that represent time since 1970 are derived from the system's clock,
+which may sometimes move backwards
+(for example, from NTP or manual adjustment),
+causing the timestamp values to decrease over time.
+They may also remain the same due to the limitation of millisecond resolution.
+Thus, for time stamps that do not need to correspond to an absolute time,
+consider using {{DOMHighResTimeStamp}},
+which provides monotonically non-decreasing sub-millisecond timestamps
+that are comparable within a single <a>browsing context</a> or web worker.
+See [[!HIGHRES-TIME]] for more details.
 
 <h3 id="error-types">Use Error or DOMException for errors</h3>
 


### PR DESCRIPTION
At the TAG face-to-face in London last week, @timbl raised the concern that the document seem to be claiming that time is not monotonically increasing, when in fact that's basically the characteristic that makes time what it is.

This pull request attempts to improve the wording of the section in question.  I think it incorporated feedback from a few different TAG members during a side conversation or two, but it certainly wasn't vetted by the whole TAG.