### PR TITLE
Add section on limiting features to secure contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -368,6 +368,67 @@ and on when to use promises and when not to use promises,
 see <strong><a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing
 Promise-Using Specifications</a></strong>.
 
+<h3 id="secure-context">Consider limiting new features to secure contexts</h3>
+
+It may save you significant time and effort
+to pre-emptively restrict your feature to Secure Contexts.
+
+The TAG is on the record in supporting
+an industry-wide move to [Secure the Web](https://www.w3.org/2001/tag/doc/web-https)
+and applaud [efforts](https://blog.mozilla.org/security/2017/01/20/communicating-the-dangers-of-non-secure-http/)
+to shift web traffic to secure connections.
+A great deal of effort has gone into debating
+which features should be restricted to [Secure Contexts](https://w3c.github.io/webappsec-secure-contexts/).
+Opinions vary amongst engine vendors, leading to difficult choices for feature designers.
+Some vendors require *all* new features be restricted this way,
+whereas others take a more selective approach.
+
+This backdrop makes it difficult to provide
+advice about the extent to which your feature should be restricted.
+What we *can* highlight is that Secure Context-restricted features
+face the least friction in gaining wide adoption amongst these varying regimes.
+
+Specification authors can limit most features defined in
+<a href="https://heycam.github.io/webidl/">WebIDL</a>,
+to secure contexts
+by using the
+<code>[<a href="https://w3c.github.io/webappsec-secure-contexts/#integration-idl">SecureContext</a>]</code> extended attribute
+on interfaces, namespaces, or their members (such as methods and attributes).
+Similar ways of marking features as limited to secure contexts should be added
+to other major points where the Web platform is extended over time
+(for example, the definition of a new CSS property).
+However, for some types of extension points (e.g., dispatching an event),
+limitation to secure contexts should just
+be defined in normative prose in the specification.
+
+As described in [[#feature-detect]],
+the existence of features should generally be detectable,
+so that web content can act appropriately if the feature is present or not.
+Since the detection should be the same no matter why the feature is unavailable,
+a feature that is limited to secure contexts should, in non-secure contexts,
+be indistinguishable from a feature that is not implemented.
+However, if, for some reason
+(a reason that itself requires serious justification),
+it is not possible for developers to detect whether a feature is present,
+limiting the feature to secure contexts
+might cause problems
+for libraries that may be used in either secure or non-secure contexts.
+
+If a feature would pose a risk to user privacy or security
+without the authentication, integrity, or confidentiality
+that is present only in secure contexts,
+then the feature must be limited to secure contexts,
+even if the other factors above could justify exposing it in non-secure contexts.
+For example, a feature that communicates with USB devices
+if those devices have allowed
+Web content from the site's origin
+to communicate with those USB devices
+depends on the authentication of the origin
+and the integrity of the data
+sent to the USB device,
+since sending untrusted data to a USB device could damage that device
+or compromise computers that the device connects to.
+
 <h2 id="event-design">Event Design</h2>
 
 <h3 id="always-add-event-handlers">Always add event handler attributes</h3>


### PR DESCRIPTION
I'm opening a separate PR to replace #75 so that it can stay somewhat archived in its current state.

Based on the TAG's discussion yesterday, the conclusion was that we wouldn't come to consensus on strong advice on requiring secure contexts.  Given that, @slightlyoff drafted some more explanatory text, which I've now merged with some of the still-usable advice I had in #75.