### PR TITLE
Add guidance for use of BigInt

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -656,6 +656,9 @@ Instead, you will want to stick with one of:
   :: Any nonnegative JavaScript number in the integer-representable range, throwing a
       <code highlight="js">TypeError</code> outside the range and rounding inside of it
 
+  : <code>bigint</code>
+  :: When the possible integer values range more broadly than JavaScript numbers can accurately represent
+
 Additionally, you can combine any of the above with an extra line in your algorithm to validate
 that the number is within the expected domain-specific range, and throwing or performing other
 actions in response. (While it is very rarely appropriate to modify author input by taking it
@@ -672,6 +675,16 @@ Those coming from other languages should carefully note that despite their names
 <code>long long</code> and <code>unsigned long long</code> only have 53 bits of precision, and
 not 64.
 </div>
+
+<code>bigint</code> is recommended to be used <em>only</em> in circumstances where a <code>[EnforceRange] long long</code>
+or <code>[EnforceRange] unsigned long long</code> would not work in terms of expressivity: that is, only when the value
+ranges greater than 2<sup>53</sup> or less than -2<sup>53</sup>. In particular, APIs should not use the <code>bigint</code>
+type simply because the input is an integer&mdash;<code>bigint</code> is for big integers (hence the name!).
+
+Transparent support for inputs being either JavaScript Number of BigInt types is discouraged, unless there is a
+domain-specific requirement to support it. As far as ergonomics, JavaScript developers are expected to keep track
+of whether their values are Numbers or BigInts. Sloppiness or implicit conversions here could lead to a loss of
+precision, defeating the purpose of using BigInt.
 
 <h3 id="milliseconds">Use milliseconds for time measurement</h3>
 


### PR DESCRIPTION
Only use BigInt where it is really needed! Number is good for existing
use cases, and existing APIs shouldn't "upgrade" to BigInt unless there
is a very strong reason.

Probably not ready to merge yet, as we will need more practical use cases
to emerge in the web platform to see how this comes up. For the same reason,
WebIDL support is not yet landed, and some open questions remain about how
flexible overloading/unions should be, see
https://github.com/heycam/webidl/pull/525#issuecomment-444073662

I'm putting this out for review now just in case an instance comes up in a TAG
review where someone proposes using BigInt in a specification. Please refer to
this PR for the advice I'd give, and better yet, @ me and I'm happy to take a
look as well.

cc @cynthia 