### PR TITLE
Remove out-of-date WebUSB example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -574,14 +574,6 @@ then the feature must be limited to secure contexts.
 One example of a feature that should be limited to secure contexts
 is geolocation, since the authentication and confidentiality provided by
 secure contexts reduce the risks to user privacy.
-Another example is:
-Web USB devices grant elevated privileges to specific origins that they name,
-since sending untrusted data to a USB device could damage that device
-or compromise computers that it connects to.
-Thus the feature depends
-on the authentication of the origin
-and the integrity of the data,
-and requires secure contexts.
 
 <h3 id="string-constants">Constants, enums, and bitmasks</h3>
 


### PR DESCRIPTION
The WebUSB specification no longer requires that a device explicitly name the origins that can connect to it. A discussion of why this requirement was removed is included in the [Attacking a Device](https://wicg.github.io/webusb/#attacking-a-device) section of the specification.