### PR TITLE
API naming advise about language and charset feedback in #108

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -138,7 +138,7 @@ and by name association.
 Please consult widely on names in your APIs.
 
 API naming *must* be done in easily readable US-English language and fall into the ASCII range. 
-For example `horizongalAlignment` is more English-readible name than `alignmentHorizontal`. 
+For example `horizontalAlignment` is a more English-readable name than `alignmentHorizontal`. 
 Whenever possible consider readability over brevity.
 
 Boolean properties, options, or API parameters which are asking a question about
@@ -1234,4 +1234,3 @@ so that readers can quickly decide whether they need to read the steps in detail
 url: https://w3c.github.io/hr-time/#dom-domhighrestimestamp; spec: HIGHRES-TIME; type: typedef
     text: DOMHighResTimeStamp
 </pre>
-

--- a/index.bs
+++ b/index.bs
@@ -137,6 +137,10 @@ and by name association.
 
 Please consult widely on names in your APIs.
 
+API naming *must* be done in easily readable US-English language and fall into the ASCII range. 
+For example `horizongalAlignment` is more English-readible name than `alignmentHorizontal`. 
+Whenever possible consider readability over brevity.
+
 Boolean properties, options, or API parameters which are asking a question about
 their argument *should not* be prefixed with <code>is</code>, while methods
 that serve the same purpose, given that it has no side effects, *should* be

--- a/index.bs
+++ b/index.bs
@@ -179,7 +179,7 @@ and by name association.
 Please consult widely on names in your APIs.
 
 API naming *must* be done in easily readable US English. For example `horizontalAlignment` 
-is more English-readable name than `alignmentHorizontal`. Whenever possible consider 
+is a more English-readable name than `alignmentHorizontal`. Whenever possible consider 
 readability over brevity.
 
 Names should adhere to the local language restrictions, for example CSS ident rules etc. 

--- a/index.bs
+++ b/index.bs
@@ -137,9 +137,11 @@ and by name association.
 
 Please consult widely on names in your APIs.
 
-API naming *must* be done in easily readable US-English language and fall into the ASCII range. 
-For example `horizontalAlignment` is a more English-readable name than `alignmentHorizontal`. 
-Whenever possible consider readability over brevity.
+API naming *must* be done in easily readable US English. For example `horizontalAlignment` is a 
+more English-readable name than `alignmentHorizontal`. Whenever possible consider readability over brevity.
+
+Names should adhere to the local language restrictions, for example CSS ident rules etc. 
+and *should* be in the [ASCII range](https://infra.spec.whatwg.org/#ascii-code-point).
 
 Boolean properties, options, or API parameters which are asking a question about
 their argument *should not* be prefixed with <code>is</code>, while methods

--- a/index.bs
+++ b/index.bs
@@ -4,9 +4,9 @@ Group: W3C TAG
 Shortname: design-principles
 Repository: w3ctag/design-principles
 Status: DREAM
-Editor: Travis Leithead, Microsoft, travil@microsoft.com
 Editor: Sangwhan Moon, Invited Expert, https://sangwhan.com
 Former Editor: Domenic Denicola, Google https://www.google.com/, https://domenic.me/, d@domenic.me
+Former Editor: Travis Leithead, Microsoft, travil@microsoft.com
 Abstract: This document contains a small-but-growing set of design principles collected by the W3C TAG while <a href="https://github.com/w3ctag/spec-reviews/">reviewing</a> specifications.
 Default Biblio Status: current
 Markup Shorthands: markdown on
@@ -432,61 +432,7 @@ the API visibly relates to garbage collection details. By contrast, special APIs
 purpose such as `WeakRef` and `FinalizationGroup` have their GC interaction as a specific part of
 their contract with the developer.
 
-<h2 id="api-surface">API Surface Concerns</h2>
-
-<h3 id="naming-is-hard">Naming things</h3>
-
-Naming is hard! We would all like a silver-bullet for naming APIs...
-
-Names take meaning from:
-
-* signposting (the name itself)
-* use (how people come to understand the name over time)
-* context (the object on the left-hand side, for example)
-
-Consistency is a good principle that helps to create a platform that users can navigate intuitively
-and by name association.
-
-Please consult widely on names in your APIs.
-
-API naming *must* be done in easily readable US English. For example `horizontalAlignment` is a 
-more English-readable name than `alignmentHorizontal`. Whenever possible consider readability over brevity.
-
-Names should adhere to the local language restrictions, for example CSS ident rules etc. 
-and *should* be in the [ASCII range](https://infra.spec.whatwg.org/#ascii-code-point).
-
-Boolean properties, options, or API parameters which are asking a question about
-their argument *should not* be prefixed with <code>is</code>, while methods
-that serve the same purpose, given that it has no side effects, *should* be
-prefixed with <code>is</code> to be consistent with the rest of the platform.
-
-The name should not be directly associated with a brand or specific revision of
-the underlying technology whenever possible; technology becomes obsolete, but
-since removing APIs from the web is difficult, naming should be generic and
-future-proof whenever possible.
-
-<h3 id="feature-detect">New features should be detectable</h3>
-
-The existence of new features should generally be detectable,
-so that web content can act appropriately whether the feature is present or not.
-This applies both to features that
-are not present because they are not implemented,
-and to features that may not be present in a particular configuration
-(ranging from features that are present only on particular platforms
-to features that are
-only available in secure contexts).
-
-It should generally be indistinguishable why a feature is unavailable,
-so that feature detection code written for one case of unavailability
-(e.g., the feature not being implemented yet in some browsers)
-also works in other cases
-(e.g., a library being used in a non-secure context when
-the feature is limited to secure contexts).
-
-Detection should always be possible from script,
-but in some cases the feature should also be detectable
-in the language where it is used
-(such as ''@supports'' in CSS).
+<h2 id="api-surface">JavaScript API Surface Concerns</h2>
 
 <h3 id="attributes-like-data">Attributes should behave like data properties</h3>
 
@@ -1410,3 +1356,4 @@ so that readers can quickly decide whether they need to read the steps in detail
 url: https://w3c.github.io/hr-time/#dom-domhighrestimestamp; spec: HIGHRES-TIME; type: typedef
     text: DOMHighResTimeStamp
 </pre>
+

--- a/index.bs
+++ b/index.bs
@@ -4,9 +4,9 @@ Group: W3C TAG
 Shortname: design-principles
 Repository: w3ctag/design-principles
 Status: DREAM
+Editor: Travis Leithead, Microsoft, travil@microsoft.com
 Editor: Sangwhan Moon, Invited Expert, https://sangwhan.com
 Former Editor: Domenic Denicola, Google https://www.google.com/, https://domenic.me/, d@domenic.me
-Former Editor: Travis Leithead, Microsoft, travil@microsoft.com
 Abstract: This document contains a small-but-growing set of design principles collected by the W3C TAG while <a href="https://github.com/w3ctag/spec-reviews/">reviewing</a> specifications.
 Default Biblio Status: current
 Markup Shorthands: markdown on

--- a/index.bs
+++ b/index.bs
@@ -179,7 +179,7 @@ and by name association.
 Please consult widely on names in your APIs.
 
 API naming *must* be done in easily readable US English. For example `horizontalAlignment` 
-is a more English-readable name than `alignmentHorizontal`. Whenever possible consider 
+is more English-readable name than `alignmentHorizontal`. Whenever possible consider 
 readability over brevity.
 
 Names should adhere to the local language restrictions, for example CSS ident rules etc. 

--- a/index.bs
+++ b/index.bs
@@ -432,7 +432,61 @@ the API visibly relates to garbage collection details. By contrast, special APIs
 purpose such as `WeakRef` and `FinalizationGroup` have their GC interaction as a specific part of
 their contract with the developer.
 
-<h2 id="api-surface">JavaScript API Surface Concerns</h2>
+<h2 id="api-surface">API Surface Concerns</h2>
+
+<h3 id="naming-is-hard">Naming things</h3>
+
+Naming is hard! We would all like a silver-bullet for naming APIs...
+
+Names take meaning from:
+
+* signposting (the name itself)
+* use (how people come to understand the name over time)
+* context (the object on the left-hand side, for example)
+
+Consistency is a good principle that helps to create a platform that users can navigate intuitively
+and by name association.
+
+Please consult widely on names in your APIs.
+
+API naming *must* be done in easily readable US English. For example `horizontalAlignment` is a 
+more English-readable name than `alignmentHorizontal`. Whenever possible consider readability over brevity.
+
+Names should adhere to the local language restrictions, for example CSS ident rules etc. 
+and *should* be in the [ASCII range](https://infra.spec.whatwg.org/#ascii-code-point).
+
+Boolean properties, options, or API parameters which are asking a question about
+their argument *should not* be prefixed with <code>is</code>, while methods
+that serve the same purpose, given that it has no side effects, *should* be
+prefixed with <code>is</code> to be consistent with the rest of the platform.
+
+The name should not be directly associated with a brand or specific revision of
+the underlying technology whenever possible; technology becomes obsolete, but
+since removing APIs from the web is difficult, naming should be generic and
+future-proof whenever possible.
+
+<h3 id="feature-detect">New features should be detectable</h3>
+
+The existence of new features should generally be detectable,
+so that web content can act appropriately whether the feature is present or not.
+This applies both to features that
+are not present because they are not implemented,
+and to features that may not be present in a particular configuration
+(ranging from features that are present only on particular platforms
+to features that are
+only available in secure contexts).
+
+It should generally be indistinguishable why a feature is unavailable,
+so that feature detection code written for one case of unavailability
+(e.g., the feature not being implemented yet in some browsers)
+also works in other cases
+(e.g., a library being used in a non-secure context when
+the feature is limited to secure contexts).
+
+Detection should always be possible from script,
+but in some cases the feature should also be detectable
+in the language where it is used
+(such as ''@supports'' in CSS).
 
 <h3 id="attributes-like-data">Attributes should behave like data properties</h3>
 


### PR DESCRIPTION
Following up on issue https://github.com/w3ctag/design-principles/issues/108. We are adding prose for the language and character set to be used.