### PR TITLE
Add a section on CSS principles. Fixes #126

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -352,34 +352,6 @@ secure contexts reduce the risks to user privacy.
 
 <h2 id="css">Cascading Style Sheets (CSS)</h2>
 
-<h3 id="css-versus-markup">Presentation should be in CSS, content should be in HTML</h3>
-
-The separation between CSS (style) and HTML (markup) was originally designed around the idea
-that the HTML is for the *content* and
-the CSS is for the *presentation* of that content.
-The CSS was intended to be optional,
-and the HTML intended so that it could be fully understood without the CSS.
-While the idea that the CSS can be dropped and the markup can still be usable
-may not make sense for *applications* built using web technologies,
-it still seems like a separation worth maintaining for *documents*,
-which remain a major use of web technology.
-
-If non-visual consumers of a page (such as search engines or screenreaders)
-seem likely to need the information (at least for well-designed pages),
-then it probably belongs in the markup rather than in the CSS.
-
-<p class="example">For example, information about the human language (English, Chinese, Arabic, etc.)
-that the text is in belongs in the markup
-(in particular, the <code><a href="https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes">lang</a></code> attribute),
-even though a number of the uses of that information (such as font selection or hyphenation)
-are related to the presentation.
-On the other hand, information about the font size makes sense to be in the style,
-since in pages that use HTML correctly
-the information shown by font sizes should also be obtainable from the markup
-(e.g., <code highlight="html">&lt;h1&gt;</code>, <code highlight="html">&lt;strong&gt;</code>)
-even though on some poorly designed pages the notion of what is a heading might not be visible to search engines or screenreaders except through the style
-(e.g., <code highlight="html">&lt;div style="font-size: 1.8em"&gt;</code>).
-
 <h3 id="css-property-separation">Separate CSS properties based on what should cascade separately</h3>
 
 Decisions about what should be in the same CSS property or in different CSS properties

--- a/index.bs
+++ b/index.bs
@@ -353,16 +353,50 @@ secure contexts reduce the risks to user privacy.
 
 <h3 id="css-versus-markup">Presentation should be in CSS, content should be in HTML</h3>
 
-CSS originally intended as optional... maybe we've moved past that?
+The separation between CSS and HTML was originally designed around the idea
+that the HTML is for the *content* and
+the CSS is for the *presentation* of that content.
+The CSS was intended to be optional,
+and the HTML intended so that it could be fully understood without the CSS.
+While the idea that the CSS can be dropped and the markup can still be usable
+may not make sense for *applications* built using web technologies,
+it still seems like a separation worth maintaining for *documents*,
+which remain a major use of web technology.
 
-But still:
-- a11y tools
-- copy/paste
-
-Things that are essential to understanding the content should be in the markup.
-For example, the content's language belongs in the <{html/lang}> attribute, not in CSS.
+If non-visual consumers of a page (such as search engines or screenreaders)
+seem likely to need the information (at least for well-designed pages),
+then it probably belongs in the markup rather than in the CSS.
+For example, information about the human language (English, Chinese, Arabic, etc.)
+that the text is in belongs in the markup
+(in particular, the <code><a href="https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes">lang</a></code> attribute),
+even though a number of the uses of that information (such as font selection or hyphenation)
+are related to the presentation.
+On the other hand, information about the font size makes sense to be in the style,
+since in pages that use HTML correctly
+the information in font sizes should also be obtainable from the markup
+(e.g., <code highlight="html">&lt;h1&gt;</code>, <code highlight="html">&lt;strong&gt;</code>)
+even though on some poorly designed pages the notion of what is a heading might not be visible to search engines or screenreaders except through the style
+(e.g., <code highlight="html">&lt;div style="font-size: 1.8em"&gt;</code>).
 
 <h3 id="css-property-separation">Separate CSS properties based on what should cascade separately</h3>
+
+Decisions about what should be in the same CSS property or in different CSS properties
+should be based on what makes sense to set independently.
+CSS cascading allows declarations (which are property-value pairs)
+from different rules or different style sheets
+to override one another in a process called the cascade.
+Thus things that should always be set together belong in the same properties,
+but things that make sense to set in different places should be in separate properties.
+
+For example, the "size" and "sink" aspects of the 'initial-letters' property
+belong in a single property
+because they are part of a single initial letter effect
+(e.g., a drop cap, sunken cap, or raised cap)
+and should nearly always be specified together.
+However, the 'initial-letters-align' property should be separate because it
+sets an alignment policy for all of these effects across the document
+which is a general stylistic choice
+and a function of the script (e.g., Latin, Cyrillic, Arabic) used in the document.
 
 <h3 id="css-inherited-or-not">Make appropriate choices for whether CSS properties are inherited</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -416,6 +416,14 @@ If setting the property on a descendant element is a separate effect
 that adds to setting it on an ancestor,
 then the property should probably not be inherited.
 
+One specific example that is common is that if a property has an effect on text,
+then it is almost always in the class where
+a descendant element needs to override (rather than add to) the effect of setting it on an ancestor,
+and the property should be inherited.
+This is also needed to maintain the design principle that
+inserting an unstyled inline element around a piece of text
+does not change the appearance of that text.
+
 A specification of an non-inherited property requiring that the handling of an element
 look at the value of that property on its ancestors (which may also be slow)
 is a "code smell" that suggests that the property likely should have been inherited.

--- a/index.bs
+++ b/index.bs
@@ -503,7 +503,7 @@ of walking up the ancestor chain looking for text decorations on ancestors.
 Another important choice in the design of every CSS property
 is what its <a>computed value</a> is.
 This is an abstract description of the value that is inherited when the property inherits.
-It is also important for starting and animation [=CSS Transitions=].
+It is also important for starting and animation of [=CSS Transitions=].
 This is most important for inherited properties, but it does matter for all properties.
 
 Note: Due to a somewhat unfortunate history,

--- a/index.bs
+++ b/index.bs
@@ -507,7 +507,7 @@ and it affects the behavior of inheritance.
 
 <a href="https://wiki.csswg.org/spec/property-dependencies">The dependencies
 that do affect computed values</a>
-are required not be circular.
+are required to not be circular.
 
 Making decisions about whether dependencies should affect computed values
 often involves tradeoffs of complexity.
@@ -525,7 +525,9 @@ This value is a multiple of the 'font-size',
 so if the 'font-size' is ''20px'' then this would mean the line height is ''28px''.
 
 However, the computed value in this case is the number ''1.4'', not the length ''28px''.
-This is important because the value can inherit to elements that have a different font size:
+This is important because the value can inherit to elements that have a different font size,
+and preserving the "multiple of the current element's font" behavior would be broken
+if it turned into a length at computed-value time:
 
   <pre highlight=html>
 &lt;body style="line-height: 1.4"&gt;
@@ -1561,4 +1563,3 @@ so that readers can quickly decide whether they need to read the steps in detail
 url: https://w3c.github.io/hr-time/#dom-domhighrestimestamp; spec: HIGHRES-TIME; type: typedef
     text: DOMHighResTimeStamp
 </pre>
-

--- a/index.bs
+++ b/index.bs
@@ -353,7 +353,7 @@ secure contexts reduce the risks to user privacy.
 
 <h3 id="css-versus-markup">Presentation should be in CSS, content should be in HTML</h3>
 
-The separation between CSS and HTML was originally designed around the idea
+The separation between CSS (style) and HTML (markup) was originally designed around the idea
 that the HTML is for the *content* and
 the CSS is for the *presentation* of that content.
 The CSS was intended to be optional,
@@ -374,7 +374,7 @@ even though a number of the uses of that information (such as font selection or 
 are related to the presentation.
 On the other hand, information about the font size makes sense to be in the style,
 since in pages that use HTML correctly
-the information in font sizes should also be obtainable from the markup
+the information shown by font sizes should also be obtainable from the markup
 (e.g., <code highlight="html">&lt;h1&gt;</code>, <code highlight="html">&lt;strong&gt;</code>)
 even though on some poorly designed pages the notion of what is a heading might not be visible to search engines or screenreaders except through the style
 (e.g., <code highlight="html">&lt;div style="font-size: 1.8em"&gt;</code>).
@@ -530,7 +530,7 @@ for the behavior to happen in whatever handles the computed value.
 Complexity in implementations might affect how fast things run for end users.)
 
 <div class="example">
-For example, the 'line-height' property accepts values that are integers,
+For example, the 'line-height' property accepts values that are numbers,
 such as ''line-height: 1.4''.
 This value is a multiple of the 'font-size',
 so if the 'font-size' is ''20px'' then this would mean the line height is ''28px''.
@@ -555,7 +555,7 @@ if it turned into a length at computed-value time:
 &lt;/body&gt;
   </pre>
 
-These integer values are generally the preferred values to use for 'line-height'
+These number values are generally the preferred values to use for 'line-height'
 because they inherit better than length values.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -546,11 +546,20 @@ These integer values are generally the preferred values to use for 'line-height'
 because they inherit better than length values.
 </div>
 
-<h3 id="css-naming">CSS properties are nouns, values are adjectives</h3>
+<h3 id="css-naming">Naming of CSS properties and values</h3>
 
-- nouns and adjectives
-- words separated by hyphens
-- see general naming section
+The names of CSS properties are usually nouns,
+and the names of their values are usually adjectives (although sometimes nouns).
+
+Words in properties and values are separated by hyphens.
+Abbreviations are generally avoided.
+
+The list of values of a property should generally be chosen
+so that new values can be added.
+Avoid values like ''yes'', ''no'', ''true'', ''false'',
+or things with more complex names that are basically equivalent to them.
+
+See [[#naming-is-hard]] for general (cross-language) advice on naming.
 
 <h2 id="js">JavaScript Language</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -502,8 +502,11 @@ which is actually the <a>resolved value</a>,
 which can be the result of further computation starting from the computed value.
 
 The definition of a CSS property often has interactions with other CSS properties.
-Whether those interactions affect the property's computed value is a design choice,
-and it affects the behavior of inheritance.
+It is often possible for these interactions to happen at the [=computed value=] stage
+or at a later stage such as the [=used value=].
+Since inheritance operates on the [=computed value=],
+whether an interaction should affect the value that descendants inherit
+is a major factor in the choice of where that interaction should be handled.
 
 <a href="https://wiki.csswg.org/spec/property-dependencies">The dependencies
 that do affect computed values</a>

--- a/index.bs
+++ b/index.bs
@@ -491,9 +491,60 @@ of walking up the ancestor chain looking for text decorations on ancestors.
 
 <h3 id="css-computed-value">Choose the computed value type based on how the property should inherit</h3>
 
-- what computed and resolved values are
-- `getComputedStyle` is the resolved value
-- computed value affects what inherits
+Another important choice in the design of every CSS property
+is what its <a>computed value</a> is.
+This is an abstract description of the value that is inherited when the property inherits.
+This is most important for inherited properties, but it does matter for all properties.
+
+Due to a somewhat unfortunate history,
+this is *not* the value that is returned by {{getComputedStyle()}},
+which is actually the <a>resolved value</a>,
+which can be the result of further computation starting from the computed value.
+
+The definition of a CSS property often has interactions with other CSS properties.
+Whether those interactions affect the property's computed value is a design choice,
+and it affects the behavior of inheritance.
+
+<a href="https://wiki.csswg.org/spec/property-dependencies">The dependencies
+that do affect computed values</a>
+are required not be circular.
+
+Making decisions about whether dependencies should affect computed values
+often involves tradeoffs of complexity.
+Sometimes it is less complex
+for the behavior to happen as part of the computation of the computed value;
+sometimes it is less complex 
+for the behavior to happen in whatever handles the computed value.
+(This complexity might be in the specification, in implementations, or both.
+Complexity in implementations might affect how fast things run for end users.)
+
+<div class="example">
+For example, the 'line-height' property accepts values that are integers,
+such as ''line-height: 1.4''.
+This value is a multiple of the 'font-size',
+so if the 'font-size' is ''20px'' then this would mean the line height is ''28px''.
+
+However, the computed value in this case is the number ''1.4'', not the length ''28px''.
+This is important because the value can inherit to elements that have a different font size:
+
+  <pre highlight=html>
+&lt;body style="line-height: 1.4"&gt;
+
+  &lt;p&gt;For example, this body text has a line height
+  that's 1.4 times its font size.&lt;/p&gt;
+
+  &lt;h2 style="font-size: 200%"&gt;
+    And this heading also has a line-height that's
+    1.4 times the h2's larger font size, and *not*
+    1.4 times the body's font size, which would lead
+    to text overlap
+  &lt;/h2&gt;
+&lt;/body&gt;
+  </pre>
+
+These integer values are generally the preferred values to use for 'line-height'
+because they inherit better than length values.
+</div>
 
 <h3 id="css-naming">CSS properties are nouns, values are adjectives</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -349,6 +349,41 @@ One example of a feature that should be limited to secure contexts
 is geolocation, since the authentication and confidentiality provided by
 secure contexts reduce the risks to user privacy.
 
+<h2 id="css">Cascading Style Sheets (CSS)</h2>
+
+<h3 id="css-versus-markup">Presentation should be in CSS, content should be in HTML</h3>
+
+CSS originally intended as optional... maybe we've moved past that?
+
+But still:
+- a11y tools
+- copy/paste
+
+Things that are essential to understanding the content should be in the markup.
+For example, the content's language belongs in the <{html/lang}> attribute, not in CSS.
+
+<h3 id="css-property-separation">Separate CSS properties based on what should cascade separately</h3>
+
+<h3 id="css-inherited-or-not">Make appropriate choices for whether CSS properties are inherited</h3>
+
+- font-size or color versus background or width
+
+- interesting cases like text-decoration
+
+- performance implications
+
+<h3 id="css-computed-value">Choose the computed value type based on how the property should inherit</h3>
+
+- what computed and resolved values are
+- `getComputedStyle` is the resolved value
+- computed value affects what inherits
+
+<h3 id="css-naming">CSS properties are nouns, values are adjectives</h3>
+
+- nouns and adjectives
+- words separated by hyphens
+- see general naming section
+
 <h2 id="js">JavaScript Language</h2>
 
 <h3 id="js-only">Web APIs are for JavaScript</h3>

--- a/index.bs
+++ b/index.bs
@@ -514,7 +514,7 @@ which can be the result of further computation starting from the computed value.
 The definition of a CSS property often has interactions with other CSS properties.
 It is often possible for these interactions to happen at the [=computed value=] stage
 or at a later stage such as the [=used value=].
-Since inheritance operates on the [=computed value=],
+Since inheritance operates on the computed value,
 whether an interaction should affect the value that descendants inherit
 is a major factor in the choice of where that interaction should be handled.
 

--- a/index.bs
+++ b/index.bs
@@ -35,6 +35,7 @@ url: https://w3c.github.io/IntersectionObserver/;
 url: https://wicg.github.io/ResizeObserver/;
     type: interface; text: ResizeObserver; url: #resizeobserver
 url: https://dom.spec.whatwg.org/#ref-for-concept-getelementsbytagname; type: interface; text: getElementsByTagName; for: Document
+url: https://drafts.csswg.org/css-transitions-1/#transitions; type: dfn; text: CSS Transitions
 </pre>
 
 <style>
@@ -502,9 +503,10 @@ of walking up the ancestor chain looking for text decorations on ancestors.
 Another important choice in the design of every CSS property
 is what its <a>computed value</a> is.
 This is an abstract description of the value that is inherited when the property inherits.
+It is also important for starting and animation [=CSS Transitions=].
 This is most important for inherited properties, but it does matter for all properties.
 
-Due to a somewhat unfortunate history,
+Note: Due to a somewhat unfortunate history,
 this is *not* the value that is returned by {{getComputedStyle()}},
 which is actually the <a>resolved value</a>,
 which can be the result of further computation starting from the computed value.
@@ -528,6 +530,9 @@ sometimes it is less complex
 for the behavior to happen in whatever handles the computed value.
 (This complexity might be in the specification, in implementations, or both.
 Complexity in implementations might affect how fast things run for end users.)
+
+For more information about computed values, see
+[Computed Values Patterns](https://wiki.csswg.org/spec/computed-values).
 
 <div class="example">
 For example, the 'line-height' property accepts values that are numbers,

--- a/index.bs
+++ b/index.bs
@@ -401,11 +401,93 @@ and a function of the script (e.g., Latin, Cyrillic, Arabic) used in the documen
 
 <h3 id="css-inherited-or-not">Make appropriate choices for whether CSS properties are inherited</h3>
 
-- font-size or color versus background or width
+An important choice in the design of every CSS property is whether the property is
+<a href="https://drafts.csswg.org/css-cascade-3/#inherited-property">inherited</a>.
+This affects what happens when no value is specified for the property on an element.
+If the property is not inherited, then that element gets the property's initial value.
+If the property is inherited, then that element gets the parent element's computed value.
 
-- interesting cases like text-decoration
+The decision about whether a property should be inherited should be based largely
+on what should happen when the property is specified on multiple elements.
+If setting the property on a descendant element needs to override (rather than add to)
+the effect of setting it on an ancestor,
+then the property should probably be inherited.
+If setting the property on a descendant element is a separate effect
+that adds to setting it on an ancestor,
+then the property should probably not be inherited.
 
-- performance implications
+A specification of an non-inherited property requiring that the handling of an element
+look at the value of that property on its ancestors (which may also be slow)
+is a "code smell" that suggests that the property likely should have been inherited.
+
+Likewise, a specification of an inherited property requiring that the handling of an element
+ignore the value of a property if it's the same as the value on the parent element
+is a "code smell" that suggests that the property likely should not have been inherited.
+
+<div class="example">
+For example, the 'background-image' property is not inherited.
+It causes an image to be drawn over part or all of the element
+(though this image might not be fully opaque).
+The CSS painting model allows other things to draw on top of that background,
+including the backgrounds of descendant elements.
+But specifying ''background-image: none'' on a descendant element does not
+cause a hole to be poked in the ancestor element's background,
+since the entire effect comes from the property being used on a single element.
+Setting ''background-image: none'' is useful
+to override a declaration lower in the cascade on the same element,
+but this is a different feature from replacing the backgrounds that are drawn by ancestors.
+
+If the 'background-image' property had been inherited,
+then the specification would have had to create a good bit of complexity
+to avoid a partially-transparent image
+being visibly repeated for each descendant element.
+This complexity probably would have involved
+behaving differently if the property had the same value on the parent element,
+which is the "code smell" mentioned above that suggests
+that a property likely should not have been inherited.
+</div>
+
+<div class="example">
+Another example is the 'font-size' property, which is inherited.
+It sets the size of the font used for the text in the element,
+and continues to apply to any descendants that don't
+have a declaration setting 'font-size' to a different value.
+
+If the 'font-size' property were not inherited,
+then it would probably have to have an initial value
+that requires walking up the ancestor chain to find the nearest ancestor
+that doesn't have that value.
+This is the "code smell" mentioned above that suggests
+that a property likely should have been inherited.
+</div>
+
+<div class="example">
+A more subtle example is the 'text-decoration' property.
+It could reasonably be described as either an inherited or non-inherited property,
+but the resulting behavior is different in a number of observable ways.
+
+As an inherited property,
+'text-decoration' would draw underlines (or other decorations)
+in the style and position of each piece of text.
+As a non-inherited property, it would draw underlines
+in the style and position of the element that specifies 'text-decoration'.
+These behaviors lead to different results
+when the element that has 'text-decoration' declared
+has descendants that are at a different vertical-alignment (e.g., superscripts),
+in a different color,
+or in a different font size.
+
+The property was designed as not inherited
+because the behavior of having underlines
+have a consistent color, thickness, and position
+was considered the better behavior.
+
+However, in the end, some of the characteristics of the other behavior
+(such as its interaction with 'visibility' or text selection)
+were also seen as desirable, and it ended up being specified in a somewhat hybrid way
+that does involve the "code smell"
+of walking up the ancestor chain looking for text decorations on ancestors.
+</div>
 
 <h3 id="css-computed-value">Choose the computed value type based on how the property should inherit</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -366,7 +366,8 @@ which remain a major use of web technology.
 If non-visual consumers of a page (such as search engines or screenreaders)
 seem likely to need the information (at least for well-designed pages),
 then it probably belongs in the markup rather than in the CSS.
-For example, information about the human language (English, Chinese, Arabic, etc.)
+
+<p class="example">For example, information about the human language (English, Chinese, Arabic, etc.)
 that the text is in belongs in the markup
 (in particular, the <code><a href="https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes">lang</a></code> attribute),
 even though a number of the uses of that information (such as font selection or hyphenation)
@@ -388,7 +389,7 @@ to override one another in a process called the cascade.
 Thus things that should always be set together belong in the same properties,
 but things that make sense to set in different places should be in separate properties.
 
-For example, the "size" and "sink" aspects of the 'initial-letters' property
+<p class="example">For example, the "size" and "sink" aspects of the 'initial-letters' property
 belong in a single property
 because they are part of a single initial letter effect
 (e.g., a drop cap, sunken cap, or raised cap)

--- a/index.bs
+++ b/index.bs
@@ -567,10 +567,17 @@ and the names of their values are usually adjectives (although sometimes nouns).
 Words in properties and values are separated by hyphens.
 Abbreviations are generally avoided.
 
+Use the root form of words when possible
+rather than a form with a grammatical prefix or suffix
+(for example, "size" rather than "sizing").
+
 The list of values of a property should generally be chosen
 so that new values can be added.
 Avoid values like ''yes'', ''no'', ''true'', ''false'',
 or things with more complex names that are basically equivalent to them.
+
+Avoid words like "mode" or "state" in the names of properties,
+since properties are generally setting a mode or state.
 
 See [[#naming-is-hard]] for general (cross-language) advice on naming.
 


### PR DESCRIPTION
This adds a somewhat substantive section on CSS to the design principles document.  It's multiple commits that are **meant to be squashed** when landed.

You should be able to [preview this here](https://dbaron.github.io/design-principles/#css) ~at some point soon, though github seems sluggish right now and it's not up yet~.

Fixes #126.

I'd like to solicit review from @tabatkins and @fantasai as well, but I can't actually mark them in reviewers.

I'm sure there's a lot that can be changed/added here -- I'd like to strike a reasonable balance between trying to polish this, and also trying to defer most "also add X" requests to later PRs.