### PR TITLE
add several HTML Design Principles related to interoperability

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -182,6 +182,26 @@ by showing how many sites are willing to ask for intrusive and unnecessary permi
 
 <h2 id="api-across-languages">API Design Across Languages</h2>
 
+<h3 id="simplicity">Prefer simple solutions</h3>
+<!-- was "Avoid Needless Complexity" in the HTML Design Principles -->
+
+Simple solutions are preferred to complex ones, when possible.
+Simpler features are easier for user agents to implement and test,
+more likely to be interoperable,
+and easier for authors to understand. [[LEAST-POWER]]
+
+But this should not be used as an excuse to avoid satisfying the other principles.
+
+<h3 id="handle-errors">Prefer graceful error recovery</h3>
+<!-- was "Handle Erros" in the HTML Design Principles -->
+
+Error handling should be defined
+so that interoperable implementations can be achieved.
+
+Prefer graceful error recovery to hard failure,
+so that users are not exposed to authoring errors,
+per the [[#priority-of-constituencies]].
+
 <h3 id="naming-is-hard">Naming things</h3>
 
 Names take meaning from:
@@ -1882,7 +1902,28 @@ Some useful advice on how to write specifications is available elsewhere:
   * <a href="https://www.w3.org/TR/qaframe-spec/">QA Framework:
     Specification Guidelines</a> (W3C QA Working Group, 2005)
 
-<h3 id="algorithms">Specify clearly enough so that algorithms are unambiguous</h3>
+<h3 id="avoid-ambiguity">Specify completely and avoid ambiguity</h3>
+<!-- was "Well-defined behavior" in the HTML Design Principles -->
+
+Whenever differences could be observable to web content
+and there isn't a good reason to allow variation between implementations,
+it is important that they be specified unambiguously,
+so that implementations interoperate
+and web content doesn't end up
+depending on the [=implementation-defined=] behavior
+in one implementation and failing in another
+(which can cause higher development costs to fix the content for all browsers,
+or costs to users of broken content if it wasn't detected).
+This way,
+it is easier to author content
+that works in a variety of user agents.
+However,
+implementations should still be free
+to make improvements
+in areas such as user interface
+and quality of rendering.
+
+<h4 id="algorithms">Defining algorithms in specifications</h4>
 
 Specification text is often more precise
 when it is written using an explicit sequence of steps.
@@ -1892,21 +1933,8 @@ a specification that describes the behavior using a sequence of steps
 will make it clear which error will be reported,
 since the different errors would be checked and reported in different steps.
 
-Likewise, describing state using explicit flags also makes behavior clearer.
-Using explicit flags makes it clear
-whether or not the state changes in different error conditions,
-and makes it clear when the state described by the flags is reset.
-
-Whenever these differences could be observable to web content
-and there isn't a good reason to allow variation between implementations,
-it is important that they be specified unambiguously,
-so that implementations interoperate
-and web content doesn't end up
-depending on the behavior of one implementation and failing in another
-(which can cause higher development costs to fix the content for all browsers,
-or costs to users of broken content if it wasn't detected).
-
-However, sequences of steps are not the only way of making the specification precise enough.
+However, sequences of steps
+are not the only way to make a specification precise enough.
 When there are particular characteristics
 that specification editors want to ensure the specification always satisfies,
 it may be better to use a less algorithmic way of formal specification
@@ -1958,6 +1986,13 @@ However, it's often useful to explain the purpose of the algorithm in prose
 (e.g., "take the following steps, which ensure that there is at most one pending X
 callback per toplevel browsing context")
 so that readers can quickly decide whether they need to read the steps in detail.
+
+<h4 id="use-flags-for-states">Use explicit flags for state</h4>
+
+Describing state using explicit flags makes behavior clearer.
+Using explicit flags makes it clear
+whether or not the state changes in different error conditions,
+and makes it clear when the state described by the flags is reset.
 
 <!-- Route around bugs in other specs.
      https://github.com/whatwg/html/issues/5515

--- a/index.bs
+++ b/index.bs
@@ -1888,14 +1888,14 @@ for the APIs that they design.
 
 The web platform is,
 unusually,
-designed to be robust in accepting poorly formed markup.
+designed to be robust in accepting poorly-formed markup.
 
 When writing specifications for the web,
 be sure to note authoring requirements
 for well-formed markup (the "conforming language"),
 and also
 implementation requirements
-for handling poorly formed markup (the "supported language").
+for handling poorly-formed markup (the "supported language").
 
 This allows us to
 have a relatively clean and understandable language for authors,

--- a/index.bs
+++ b/index.bs
@@ -1894,13 +1894,31 @@ This document mostly covers API design for the Web,
 but those who design APIs are hopefully also writing specifications
 for the APIs that they design.
 
-<h3 id="writing-resources">Other resources</h3>
+<h3 id="requirements-on-authors-and-implementers">Identify the audience of the requirements in your specification</h3>
+<!-- was "Conformance for Documents and Implementations" in the HTML Design Principles -->
 
-Some useful advice on how to write specifications is available elsewhere:
-  * <a href="https://ln.hixie.ch/?start=1140242962&amp;count=1">Writing
-    specifications: Kinds of statements</a> (Ian Hickson, 2006)
-  * <a href="https://www.w3.org/TR/qaframe-spec/">QA Framework:
-    Specification Guidelines</a> (W3C QA Working Group, 2005)
+Many language specifications
+define a set of conformance requirements for valid documents,
+and corresponding conformance requirements
+for implementations processing these valid documents.
+The web platform is somewhat unusual
+in also defining implementation conformance requirements
+for many constructs that are not allowed in conforming documents.
+
+This allows us to
+have a relatively clean and understandable language for authors,
+while at the same time supporting existing documents
+that make use of older or nonstandard constructs,
+and enabling better interoperability in error handling.
+
+Some of the design principles in this document apply much more
+to conformance requirements for content (the "conforming language")
+while others apply much more
+to conformance requirements for implementations (the "supported language").
+Since the supported language is a strict superset of the conforming language,
+there is considerable overlap,
+but we have tried to be clear
+which set of requirements each principle applies to.
 
 <h3 id="avoid-ambiguity">Specify completely and avoid ambiguity</h3>
 <!-- was "Well-defined behavior" in the HTML Design Principles -->
@@ -1993,6 +2011,14 @@ Describing state using explicit flags makes behavior clearer.
 Using explicit flags makes it clear
 whether or not the state changes in different error conditions,
 and makes it clear when the state described by the flags is reset.
+
+<h3 id="writing-resources">Other resources</h3>
+
+Some useful advice on how to write specifications is available elsewhere:
+  * <a href="https://ln.hixie.ch/?start=1140242962&amp;count=1">Writing
+    specifications: Kinds of statements</a> (Ian Hickson, 2006)
+  * <a href="https://www.w3.org/TR/qaframe-spec/">QA Framework:
+    Specification Guidelines</a> (W3C QA Working Group, 2005)
 
 <!-- Route around bugs in other specs.
      https://github.com/whatwg/html/issues/5515

--- a/index.bs
+++ b/index.bs
@@ -1898,15 +1898,16 @@ for the APIs that they design.
 <h3 id="requirements-on-authors-and-implementers">Identify the audience of each requirement in your specification</h3>
 <!-- was "Conformance for Documents and Implementations" in the HTML Design Principles -->
 
-The web platform is, unusually, designed to be robust in accepting poorly formed markup.
+The web platform is,
+unusually,
+designed to be robust in accepting poorly formed markup.
 
-When writing specifications for the web, be sure to note authoring requirements for well formed markup ("conforming language"), but also implementation requirements for handling poorly formed markup ("supported language").
-define a set of conformance requirements for valid documents,
-and corresponding conformance requirements
-for implementations processing these valid documents.
-The web platform is somewhat unusual
-in also defining implementation conformance requirements
-for many constructs that are not allowed in conforming documents.
+When writing specifications for the web,
+be sure to note authoring requirements
+for well formed markup (the "conforming language"),
+and also
+implementation requirements
+for handling poorly formed markup (the "supported language").
 
 This allows us to
 have a relatively clean and understandable language for authors,
@@ -1932,7 +1933,7 @@ this adds a maintenance burden for authors.
 
 The specification should be complete enough 
 for implementations to be interoperable,
-without depending on referring to the details of other implementations.
+without depending on or referring to the details of other implementations.
 and there isn't a good reason to allow variation between implementations,
 it is important that they be specified unambiguously,
 so that implementations interoperate

--- a/index.bs
+++ b/index.bs
@@ -185,12 +185,11 @@ by showing how many sites are willing to ask for intrusive and unnecessary permi
 <h3 id="simplicity">Prefer simple solutions</h3>
 <!-- was "Avoid Needless Complexity" in the HTML Design Principles -->
 
-Simple solutions are preferred to complex ones, when possible.
+Simple solutions are generally better than complex solutions,
+although they may be harder to find.
 Simpler features are easier for user agents to implement and test,
 more likely to be interoperable,
 and easier for authors to understand. [[LEAST-POWER]]
-
-But this should not be used as an excuse to avoid satisfying the other principles.
 
 <h3 id="handle-errors">Prefer graceful error recovery</h3>
 <!-- was "Handle Erros" in the HTML Design Principles -->
@@ -201,6 +200,8 @@ so that interoperable implementations can be achieved.
 Prefer graceful error recovery to hard failure,
 so that users are not exposed to authoring errors,
 per the [[#priority-of-constituencies]].
+
+<!-- TODO: add an example and a counter-example -->
 
 <h3 id="naming-is-hard">Naming things</h3>
 
@@ -2011,6 +2012,8 @@ Describing state using explicit flags makes behavior clearer.
 Using explicit flags makes it clear
 whether or not the state changes in different error conditions,
 and makes it clear when the state described by the flags is reset.
+
+<!-- TODO: add examples -->
 
 <h3 id="writing-resources">Other resources</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -191,18 +191,6 @@ Simpler features are easier for user agents to implement and test,
 more likely to be interoperable,
 and easier for authors to understand. See related [[LEAST-POWER]]
 
-<h3 id="handle-errors">Prefer graceful error recovery</h3>
-<!-- was "Handle Errors" in the HTML Design Principles -->
-
-Error handling should be defined
-so that interoperable implementations can be achieved.
-
-Prefer graceful error recovery to hard failure,
-so that users are not exposed to authoring errors,
-per the [[#priority-of-constituencies]].
-
-<!-- TODO: add an example and a counter-example -->
-
 <h3 id="naming-is-hard">Naming things</h3>
 
 Names take meaning from:

--- a/index.bs
+++ b/index.bs
@@ -189,10 +189,10 @@ Simple solutions are generally better than complex solutions,
 although they may be harder to find.
 Simpler features are easier for user agents to implement and test,
 more likely to be interoperable,
-and easier for authors to understand. [[LEAST-POWER]]
+and easier for authors to understand. See related [[LEAST-POWER]]
 
 <h3 id="handle-errors">Prefer graceful error recovery</h3>
-<!-- was "Handle Erros" in the HTML Design Principles -->
+<!-- was "Handle Errors" in the HTML Design Principles -->
 
 Error handling should be defined
 so that interoperable implementations can be achieved.
@@ -1895,10 +1895,12 @@ This document mostly covers API design for the Web,
 but those who design APIs are hopefully also writing specifications
 for the APIs that they design.
 
-<h3 id="requirements-on-authors-and-implementers">Identify the audience of the requirements in your specification</h3>
+<h3 id="requirements-on-authors-and-implementers">Identify the audience of each requirement in your specification</h3>
 <!-- was "Conformance for Documents and Implementations" in the HTML Design Principles -->
 
-Many language specifications
+The web platform is, unusually, designed to be robust in accepting poorly formed markup.
+
+When writing specifications for the web, be sure to note authoring requirements for well formed markup ("conforming language"), but also implementation requirements for handling poorly formed markup ("supported language").
 define a set of conformance requirements for valid documents,
 and corresponding conformance requirements
 for implementations processing these valid documents.
@@ -1924,7 +1926,13 @@ which set of requirements each principle applies to.
 <h3 id="avoid-ambiguity">Specify completely and avoid ambiguity</h3>
 <!-- was "Well-defined behavior" in the HTML Design Principles -->
 
-Whenever differences could be observable to web content
+If the specification leaves room for implementations to make different choices
+which mean authors need to write different markup for different implementations,
+this adds a maintenance burden for authors. 
+
+The specification should be complete enough 
+for implementations to be interoperable,
+without depending on referring to the details of other implementations.
 and there isn't a good reason to allow variation between implementations,
 it is important that they be specified unambiguously,
 so that implementations interoperate

--- a/index.bs
+++ b/index.bs
@@ -1892,7 +1892,7 @@ designed to be robust in accepting poorly formed markup.
 
 When writing specifications for the web,
 be sure to note authoring requirements
-for well formed markup (the "conforming language"),
+for well-formed markup (the "conforming language"),
 and also
 implementation requirements
 for handling poorly formed markup (the "supported language").
@@ -1902,15 +1902,6 @@ have a relatively clean and understandable language for authors,
 while at the same time supporting existing documents
 that make use of older or nonstandard constructs,
 and enabling better interoperability in error handling.
-
-Some of the design principles in this document apply much more
-to conformance requirements for content (the "conforming language")
-while others apply much more
-to conformance requirements for implementations (the "supported language").
-Since the supported language is a strict superset of the conforming language,
-there is considerable overlap,
-but we have tried to be clear
-which set of requirements each principle applies to.
 
 <h3 id="avoid-ambiguity">Specify completely and avoid ambiguity</h3>
 <!-- was "Well-defined behavior" in the HTML Design Principles -->
@@ -1922,8 +1913,8 @@ this adds a maintenance burden for authors.
 The specification should be complete enough 
 for implementations to be interoperable,
 without depending on or referring to the details of other implementations.
-and there isn't a good reason to allow variation between implementations,
-it is important that they be specified unambiguously,
+When there isn't a good reason to allow variation between implementations,
+it is important that things be specified unambiguously,
 so that implementations interoperate
 and web content doesn't end up
 depending on the [=implementation-defined=] behavior


### PR DESCRIPTION
This PR adds text from four sections of the HTML Design Principles doc:

* 1.1 Conformance for Documents and Implementations
* 4.1 Well-Defined Behavior
* 4.2 Avoid Needless Complexity

The text for Avoid Needless Complexity and Handle Errors is mostly unchanged, though I did tweak it a bit and retitled them.

The existing text on writing algorithms covered most of "Well-Defined Behavior".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/190.html" title="Last updated on May 29, 2020, 12:33 AM UTC (7e98a01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/190/af8e2ad...7e98a01.html" title="Last updated on May 29, 2020, 12:33 AM UTC (7e98a01)">Diff</a>