### PR TITLE
Add a subsection about using "unsafe" in names.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -382,16 +382,15 @@ initialisms, even if they are repeated.
 
 <h4 id="naming-unsafe" class="no-num no-toc">Warning about dangerous features</h4>
 
-Many specifications provide guarantees or invariants to developers who use them.
-For example,
-[CSP](https://w3c.github.io/webappsec-csp/)
-provides protection against certain types of content injection vulnerabilities.
-Such specifications may also provide features that weaken their own invariants
-(or those of other specifications),
-such as CSP's `unsafe-inline` keyword,
-which allows inline scripts, reducing CSP's own protections.
-It is useful to mark features that weaken the invariants provided to developers
+It is useful to mark features that weaken
+the guarantees or invariants provided to developers
 by making their names start with "unsafe" so that this is more noticeable.
+For example,
+[Content Security Policy (CSP)](https://w3c.github.io/webappsec-csp/)
+provides protection against certain types of content injection vulnerabilities.
+CSP also provides features that weaken this invariant,
+such as the `unsafe-inline` keyword,
+which reduces CSP's own protections by allowing inline scripts.
 
 <h3 id="feature-detect">New features should be detectable</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -383,13 +383,13 @@ initialisms, even if they are repeated.
 <h4 id="naming-unsafe" class="no-num no-toc">Warning about dangerous features</h4>
 
 Where possible, mark features that weaken
-the guarantees or invariants provided to developers
+the guarantees provided to developers
 by making their names start with "unsafe" so that this is more noticeable.
 
 For example,
 [Content Security Policy (CSP)](https://w3c.github.io/webappsec-csp/)
 provides protection against certain types of content injection vulnerabilities.
-CSP also provides features that weaken this invariant,
+CSP also provides features that weaken this guarantee,
 such as the `unsafe-inline` keyword,
 which reduces CSP's own protections by allowing inline scripts.
 

--- a/index.bs
+++ b/index.bs
@@ -380,6 +380,19 @@ examples that violate the above rules are {{XMLHttpRequest}} and
 initialisms, even if they are repeated.
 </div>
 
+<h4 id="naming-unsafe" class="no-num no-toc">Warning about dangerous features</h4>
+
+Many specifications provide guarantees or invariants to developers who use them.
+For example,
+[CSP](https://w3c.github.io/webappsec-csp/)
+provides protection against certain types of content injection vulnerabilities.
+Such specifications may also provide features that weaken their own invariants
+(or those of other specifications),
+such as CSP's `unsafe-inline` keyword,
+which allows inline scripts, reducing CSP's own protections.
+It is useful to mark features that weaken the invariants provided to developers
+by making their names start with "unsafe" so that this is more noticeable.
+
 <h3 id="feature-detect">New features should be detectable</h3>
 
 The existence of new features should generally be detectable,

--- a/index.bs
+++ b/index.bs
@@ -382,9 +382,10 @@ initialisms, even if they are repeated.
 
 <h4 id="naming-unsafe" class="no-num no-toc">Warning about dangerous features</h4>
 
-It is useful to mark features that weaken
+Where possible, mark features that weaken
 the guarantees or invariants provided to developers
 by making their names start with "unsafe" so that this is more noticeable.
+
 For example,
 [Content Security Policy (CSP)](https://w3c.github.io/webappsec-csp/)
 provides protection against certain types of content injection vulnerabilities.


### PR DESCRIPTION
This was written during a breakout I just had with @atanassov.

Fixes #104.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#naming-unsafe
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/design-principles/pull/193.html#naming-unsafe" title="Last updated on Jun 3, 2020, 5:12 AM UTC (8b30698)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/193/65aeebf...dbaron:8b30698.html" title="Last updated on Jun 3, 2020, 5:12 AM UTC (8b30698)">Diff</a>