### PR TITLE
Makefile: die on Bikeshed warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ clean:
 	rm -f index.html *~
 
 .bs.html:
-	bikeshed spec $< $@
+	bikeshed --die-on=warning spec $< $@


### PR DESCRIPTION
Would have caught #202, for instance.