### PR TITLE
Add paragraph about device detection to clarify advice on feature detection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -398,6 +398,13 @@ also works in other cases
 (e.g., a library being used in a non-secure context when
 the feature is limited to secure contexts).
 
+However, some features may be for
+interaction with devices that may or may not be available.
+Detection of device availability should generally be separate from feature detection,
+both since [the user may need to consent](#consent) to such detection,
+and since developers may want to handle device unavailability
+differently from lack of support for the feature.
+
 Detection should always be possible from script,
 but in some cases the feature should also be detectable
 in the language where it is used

--- a/index.bs
+++ b/index.bs
@@ -400,10 +400,10 @@ the feature is limited to secure contexts).
 
 However, some features may be for
 interaction with devices that may or may not be available.
-Detection of device availability should generally be separate from feature detection,
-both since [the user may need to consent](#consent) to such detection,
-and since developers may want to handle device unavailability
+Detection of device availability should generally be separate from feature detection.
+This helps developers who may want to handle device unavailability
 differently from lack of support for the feature.
+It also protects users; for more detail see [[#device-enumeration]].
 
 Detection should always be possible from script,
 but in some cases the feature should also be detectable


### PR DESCRIPTION
While discussing #137 with @kenchris and @atanassov I realized that the existing advice in this section could be misinterpreted.  This clarifies that advice.  (It's not a fix for that issue, though, but it is related.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#feature-detect
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/design-principles/pull/201.html#feature-detect" title="Last updated on May 28, 2020, 5:34 PM UTC (e11878b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/201/af8e2ad...dbaron:e11878b.html" title="Last updated on May 28, 2020, 5:34 PM UTC (e11878b)">Diff</a>