### PR TITLE
trim trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+
+[*.bs]
+indent_style = space
+indent_size = 4
+
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+
+[*.md]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false
+
+
+[*.{yml,yaml,yamllint}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 out/
+*.sublime-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+---
 sudo: false
 script: bash ./deploy-gh-pages.sh
 env:
   global:
-  - ENCRYPTION_LABEL: "db14bf8578f5"
-  - COMMIT_AUTHOR_EMAIL: "travis@w3ctag.org"
+    - ENCRYPTION_LABEL: "db14bf8578f5"
+    - COMMIT_AUTHOR_EMAIL: "travis@w3ctag.org"

--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,7 @@ Boilerplate: feedback-header off
 Link Defaults: html (dfn) queue a task/in parallel/reflect
 </pre>
 <pre class="link-defaults">
-spec:html; type:dfn; for:/; 
+spec:html; type:dfn; for:/;
     text:browsing context
     text:focus update steps
     text:task queue
@@ -535,7 +535,7 @@ This can and should be done
 without revealing any detectable API differences to the site.
 
 <div class="example">
-  
+
 User Agents which support [localStorage](https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage)
 should not persist storage area changes
 made while private browsing mode is engaged.
@@ -572,7 +572,7 @@ Given such dangers,
 websites should not be able to detect that private browsing mode is engaged.
 
 <div class="example">
-  
+
 User Agents which support [IndexedDB](https://www.w3.org/TR/IndexedDB/)
 should not disable it in private browsing mode,
 because that would reveal that private browsing mode is engaged
@@ -768,7 +768,7 @@ Making decisions about whether dependencies should affect computed values
 often involves tradeoffs of complexity.
 Sometimes it is less complex
 for the behavior to happen as part of the computation of the computed value;
-sometimes it is less complex 
+sometimes it is less complex
 for the behavior to happen in whatever handles the computed value.
 (This complexity might be in the specification, in implementations, or both.
 Complexity in implementations might affect how fast things run for end users.)
@@ -1043,13 +1043,13 @@ and increases user-friendliness.
 Optional parameters should be consolidated into a dictionary,
 and empty parameters should be treated identically to when the parameter is omitted.
 
-<p class="example">For example, 
-<code highlight="js">element.scrollIntoView(false, {});</code> 
-is equivalent to 
+<p class="example">For example,
+<code highlight="js">element.scrollIntoView(false, {});</code>
+is equivalent to
 <code highlight="js">element.scrollIntoView(false);</code>,
 and
 <code highlight="js">element.addEventListener("click", onClick, undefined);</code>
-is equivalent to 
+is equivalent to
 <code highlight="js">element.addEventListener("click", onClick)</code>.
 </p>
 
@@ -1310,7 +1310,7 @@ Try to design DOM events to deliver after-the-fact notifications of changes. It 
 
 <h3 id="guard-against-recursion">Guard against potential recursion</h3>
 
-When designing a long-running or complicated algorithm that is initiated by an 
+When designing a long-running or complicated algorithm that is initiated by an
 API call, events are appropriate for [[#events-are-for-notification|notifying]]
 user code of the ongoing process. However, they also introduce the possibility of unexpected
 re-execution of the current algorithm before it has finished! Because user code gets
@@ -1324,8 +1324,8 @@ is already concurrently running. This technique is "guarding" the algorithm:
 <div class="example">
     The following is a technique (e.g., as used in the [=AbortSignal/add|AbortSignal's add algorithm=]
     or as a stack-based variation in the [=focus update steps=])
-    for guarding against unplanned recursion. 
-    
+    for guarding against unplanned recursion.
+
     In this example, an object of type <dfn noexport interface>MyObject</dfn> has
     a method <dfn method for="MyObject">doComplexOpWithEvents()</dfn> and
     an internal state attribute [[<dfn noexport attribute for="MyObject">started</dfn>]]
@@ -1334,10 +1334,10 @@ is already concurrently running. This technique is "guarding" the algorithm:
     value is `false`.
 
     The {{doComplexOpWithEvents()}} method must act as follows:
-    
+
     1. If {{MyObject|this}}.[[{{started}}]] is not `false` then throw an {{InvalidStateError}}
         {{DOMException}} and terminate this algorithm.
-        
+
         Note: {{doComplexOpWithEvents()}} is not allowed to be run again
         (e.g., from within a `"currentlyinprogress"` event handler) before it finishes
         its original execution.
@@ -1353,8 +1353,8 @@ is already concurrently running. This technique is "guarding" the algorithm:
     6. Set {{MyObject|this}}.[[{{started}}]] to `false`.
 </div>
 
-Note: A caution about early termination: if the algorithm being terminated would go 
-on to ensure some critical state consistency, be sure to also make the relevant adjustments 
+Note: A caution about early termination: if the algorithm being terminated would go
+on to ensure some critical state consistency, be sure to also make the relevant adjustments
 in state before early termination of the algorithm. Not doing so can lead to inconsistent
 state and end-user-visible bugs when implemented as-specified.
 
@@ -1383,7 +1383,7 @@ applies the principle of deferral of notification — in this case to the microt
 following the algorithm.
 
 Also note that deferral of events is always necessary if the algorithm that triggers
-the event could be running on a different thread or process. In this case deferral 
+the event could be running on a different thread or process. In this case deferral
 ensures the events can be processed on the correct task in the [=task queue=].
 
 Both approaches to protecting against unwanted recursion have trade-offs. Some things
@@ -1400,14 +1400,14 @@ to consider when choosing the guarding approach:
     object they were fired on (avoiding the need to derive a new type of {{Event}}
     to hold such state snapshots).
 
-When deferring, event handlers will run after the algorithm ends (or starts 
-to run [=in parallel=]) and any number of other tasks or microtasks may run in between 
+When deferring, event handlers will run after the algorithm ends (or starts
+to run [=in parallel=]) and any number of other tasks or microtasks may run in between
 that invalidate the object's state. Since the object's state will be unknown when
 the deferred event is dispatched, consider the following:
 
-* state relevant to the event should be packaged with the deferred event, usually 
+* state relevant to the event should be packaged with the deferred event, usually
     involving a new {{Event}}-derived type with new attributes to hold the state.
-    For example, the {{ProgressEvent}} adds {{ProgressEvent/loaded}}, 
+    For example, the {{ProgressEvent}} adds {{ProgressEvent/loaded}},
     {{ProgressEvent/total}}, etc. attributes to hold the state.
 * any coordination needed among parts of an algorithm using deferred events often
     requires defining an explicit state machine (well-defined state transitions) to
@@ -1415,15 +1415,15 @@ the deferred event is dispatched, consider the following:
     state is well-defined. For example, in [[payment-request]], the {{PaymentRequest}}'s
     [=[[state]]=] internal slot explicitly tracks the object's state
     through its well-defined transitions.
-    * in addition to defining state transitions, each coordinated algorithm usually 
+    * in addition to defining state transitions, each coordinated algorithm usually
         applies the guarding technique (anyway) to ensure the algorithm can only proceed
         under the appropriate set of states. For example, in [[payment-request]] note
         the guards used often around the [=[[state]]=] internal
         slot such as in the {{MerchantValidationEvent/complete()}} algorithm.
-    
+
 Finally, dispatching a deferred event that does not seem to require
 packaging extra state or defining a state machine for the algorithm as mentioned above,
-could mean that all of the state transitions have been completed and that the event 
+could mean that all of the state transitions have been completed and that the event
 is meant to signal completion of the algorithm. In this case, it's likely that instead
 of using an event to signal completion, the API should be designed to return and complete
 a {{Promise}} instead. See [[#one-time-events]].
@@ -1769,7 +1769,7 @@ that this is done in a consistent and privacy-friendly way:
     deterministically producing the same id
     in subsequent sessions.
 
-<h3 id="device-enumeration">Use care when exposing APIs for selecting or enumerating devices</h3> 
+<h3 id="device-enumeration">Use care when exposing APIs for selecting or enumerating devices</h3>
 
 APIs which expose the the existence, capabilities, and/or identifiers of many devices
 risk multiplying the harm described in [[#device-ids]]
@@ -1931,12 +1931,12 @@ that should be considered in the development of new features, notably:
 <h3 id="extend-manifests">Extend existing manifest files rather than creating new ones</h3>
 
 New web features should be self-contained and self-describing and ideally should not require an additional manifest file.
-Manifest files can add complexity to the development and deployment process for web technologies.  Sometimes manifest 
+Manifest files can add complexity to the development and deployment process for web technologies.  Sometimes manifest
 files are required, but the use of different manifests on the web should be kept to a minimum.
 
 You may need to make a new manifest file if the domain of the manifest file is different from the existing manifest files.
-For example, if the fetch timing is different, or if the complexity of the manifest warrants it.  Application metadata should be added 
-to the Web App Manifest or be an extension of it. 
+For example, if the fetch timing is different, or if the complexity of the manifest warrants it.  Application metadata should be added
+to the Web App Manifest or be an extension of it.
 Manifests designated to be used for specific applications or which require interoperability with non-browsers may need to take a different approach.
 Payment Method Manifest, Publication Manifest, and Origin Policy are examples of these cases.
 
@@ -1945,14 +1945,14 @@ it is probably best to use an existing manifest (or ideally design the feature i
 However, if your feature requires a complex set of metadata specific to a functional domain, the creation of a new manifest may be justified.
 
 Note that in all cases, the naming conventions should be harmonized (see section 2.2)
- 
+
 Note: By principle, existing manifests use lowercase, underscore-delimited names.
 There have been times where it has been beneficial to re-use dictionaries from a manifest in DOM APIs as well, which are camel-cased.
-One such example is the <a href="https://w3c.github.io/image-resource/">image resource</a>. For this reason, if a 
+One such example is the <a href="https://w3c.github.io/image-resource/">image resource</a>. For this reason, if a
 key can clearly be expressed as a single word, that is recommended.
- 
+
 When designing new keys and values for a manifest, make sure they are needed (that is, they enable well-thought-out use-cases).
-Also, please check if a similar key exists. If an existing key/value pair does more or less what is needed, 
+Also, please check if a similar key exists. If an existing key/value pair does more or less what is needed,
 work with the existing spec to extend it to your use-case if possible.
 
 Some of the existing manifest files include
@@ -1966,17 +1966,17 @@ We encourage people to think of manifest files as extensible.
 Always try to get the changes into the original spec, or at least discuss the extension with the spec editors.
 Having this discussion is more likely to result in a better design and lead to something that better integrates with the platform.
 
-There are certain times the spec authors might not want to 
+There are certain times the spec authors might not want to
 integrate immediately due to process (like going to CR) or due to it having a different scope, like extensions to Web App
-Manifest only affecting store or payment use-cases. In that case, it is acceptable to monkey-patch as long as that is agreed 
+Manifest only affecting store or payment use-cases. In that case, it is acceptable to monkey-patch as long as that is agreed
 with the original spec editors.
 
 ISSUE(184): when we write up a principle on monkey patching, be sure to take this nuance into account.
 
-An example of something that was done as a monkey patch that is scheduled to be integrated into the web app manifest in 
+An example of something that was done as a monkey patch that is scheduled to be integrated into the web app manifest in
 a future level (post-CR):
 
-* https://wicg.github.io/web-share-target/#extension-to-the-web-app-manifest 
+* https://wicg.github.io/web-share-target/#extension-to-the-web-app-manifest
 
 <h2 id="spec-writing">Writing good specifications</h2>
 
@@ -2009,9 +2009,9 @@ and enabling better interoperability in error handling.
 
 If the specification leaves room for implementations to make different choices
 which mean authors need to write different markup for different implementations,
-this adds a maintenance burden for authors. 
+this adds a maintenance burden for authors.
 
-The specification should be complete enough 
+The specification should be complete enough
 for implementations to be interoperable,
 without depending on or referring to the details of other implementations.
 When there isn't a good reason to allow variation between implementations,


### PR DESCRIPTION
also added .editorconfig to set editor features
cleaned up yaml formatting


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/plinss/design-principles/pull/206.html" title="Last updated on May 29, 2020, 2:34 AM UTC (32a99a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/206/9e66738...plinss:32a99a0.html" title="Last updated on May 29, 2020, 2:34 AM UTC (32a99a0)">Diff</a>