### PR TITLE
Add an Acknowledgments section.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9,7 +9,7 @@ ED: https://w3ctag.github.io/design-principles/
 Editor: Sangwhan Moon, Invited Expert, https://sangwhan.com
 Former Editor: Domenic Denicola, Google https://www.google.com/, https://domenic.me/, d@domenic.me
 Former Editor: Travis Leithead, Microsoft, travil@microsoft.com
-Abstract: This document contains a set of design principles to be used when designing Web Platform technologies. These principles have been collected during the Technical Architecture Group's discussions in <a href="https://github.com/w3ctag/spec-reviews/">reviewing</a> developing specifications. We encourage specification designers to read this document and use it as a resource when making design decisions.
+Abstract: This document contains a set of design principles to be used when designing Web Platform technologies. These principles have been collected during the Technical Architecture Group's discussions in <a href="https://github.com/w3ctag/design-reviews/">reviewing</a> developing specifications. We encourage specification designers to read this document and use it as a resource when making design decisions.
 Default Biblio Status: current
 Markup Shorthands: markdown on
 Boilerplate: feedback-header off
@@ -2152,3 +2152,101 @@ urlPrefix: https://w3c.github.io/remote-playback/; spec: REMOTE-PLAYBACK
 urlPrefix: https://url.spec.whatwg.org/; spec: URL;
     type: abstract-op; url: #percent-encode; text: percent-encode
 </pre>
+
+<h2 id="acks" class="no-num">Acknowledgments</h2>
+
+This document consists of
+principles which have been collected
+by TAG members past and present
+during TAG [design reviews](https://github.com/w3ctag/design-reviews/).
+We are indebted to everyone who has requested a design review from us.
+
+The TAG would like to thank
+Adrian Hope-Bailie,
+Alan Stearns,
+Aleksandar Totic,
+Alex Russell,
+<!-- Alice Boxhall, (current TAG member) -->
+Andreas Stöckel,
+Andrew Betts,
+Anne van Kesteren,
+Benjamin C. Wiley Sittler,
+Boris Zbarsky,
+Brian Kardell,
+Charles McCathieNevile,
+Chris Wilson,
+Dan Connolly,
+<!-- Daniel Appelquist, (current TAG member) -->
+Daniel Ehrenberg,
+Daniel Murphy,
+<!-- David Baron, (current TAG member) -->
+Domenic Denicola,
+Eiji Kitamura,
+Eric Shepherd,
+Ethan Resnick,
+fantasai,
+François Daoust,
+<!-- Hadley Beeman, (current TAG member) -->
+Henri Sivonen,
+HE Shi-Jun,
+Ian Hickson,
+Irene Knapp,
+Jake Archibald,
+Jeffrey Yasskin,
+Jeremy Roman,
+Jirka Kosek,
+<!-- Kenneth Rohde Christiansen, (current TAG member) -->
+Kevin Marks,
+Lachlan Hunt,
+Léonie Watson,
+L. Le Meur,
+Lukasz Olejnik,
+Maciej Stachowiak,
+Marcos Cáceres,
+Mark Nottingham,
+Martin Thomson,
+Matt Giuca,
+Matt Wolenetz,
+Michael[tm] Smith,
+Mike West,
+Nick Doty,
+Nigel Megitt,
+Nik Thierry,
+Ojan Vafai,
+Olli Pettay,
+Pete Snyder,
+<!-- Peter Linss, (current TAG member) -->
+Philip Jägenstedt,
+Philip Taylor,
+Reilly Grant,
+Richard Ishida,
+Rick Byers,
+<!-- Rossen Atanassov, (current TAG member) -->
+Ryan Sleevi,
+<!-- Sangwhan Moon, (current TAG member) -->
+Sergey Konstantinov,
+Stefan Zager,
+Stephen Stewart,
+Steven Faulkner,
+Surma,
+Tab Atkins-Bittner,
+Tantek Çelik,
+<!-- Theresa O'Connor, (current TAG member) -->
+<!-- Tim Berners-Lee, (current TAG member) -->
+Tobie Langel,
+Travis Leithead,
+and
+Yoav Weiss
+<!-- Yves Lafon (current TAG member) -->
+for their contributions to this & the [HTML Design Principles](https://www.w3.org/TR/html-design-principles/) document which preceded it.
+
+Special thanks to
+Anne van Kesteren
+and
+Maciej Stachowiak,
+who edited the [HTML Design Principles](https://www.w3.org/TR/html-design-principles/) document.
+
+If you contributed to this document
+but your name is not listed above,
+please let the editors know
+so they can correct this omission.

--- a/index.bs
+++ b/index.bs
@@ -39,6 +39,20 @@ url: https://wicg.github.io/ResizeObserver/;
 url: https://dom.spec.whatwg.org/#ref-for-concept-getelementsbytagname; type: interface; text: getElementsByTagName; for: Document
 url: https://drafts.csswg.org/css-transitions-1/#transitions; type: dfn; text: CSS Transitions
 </pre>
+<!-- Route around bugs in other specs.
+     https://github.com/whatwg/html/issues/5515
+     https://github.com/w3c/remote-playback/issues/137
+     https://github.com/whatwg/url/issues/522
+     -->
+<pre class="anchors">
+urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
+    text: file; for: input/type; type: attr-value; url: input.html#file-upload-state-%28type=file%29
+urlPrefix: https://w3c.github.io/remote-playback/; spec: REMOTE-PLAYBACK
+    text: RemotePlayback; type:interface; url: #remoteplayback-interface
+    text: remote playback device; type:dfn; url: #dfn-remote-playback-devices
+urlPrefix: https://url.spec.whatwg.org/; spec: URL;
+    type: abstract-op; url: #percent-encode; text: percent-encode
+</pre>
 
 <style>
     table.data {
@@ -2137,21 +2151,6 @@ Some useful advice on how to write specifications is available elsewhere:
     specifications: Kinds of statements</a> (Ian Hickson, 2006)
   * <a href="https://www.w3.org/TR/qaframe-spec/">QA Framework:
     Specification Guidelines</a> (W3C QA Working Group, 2005)
-
-<!-- Route around bugs in other specs.
-     https://github.com/whatwg/html/issues/5515
-     https://github.com/w3c/remote-playback/issues/137
-     https://github.com/whatwg/url/issues/522
-     -->
-<pre class="anchors">
-urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
-    text: file; for: input/type; type: attr-value; url: input.html#file-upload-state-%28type=file%29
-urlPrefix: https://w3c.github.io/remote-playback/; spec: REMOTE-PLAYBACK
-    text: RemotePlayback; type:interface; url: #remoteplayback-interface
-    text: remote playback device; type:dfn; url: #dfn-remote-playback-devices
-urlPrefix: https://url.spec.whatwg.org/; spec: URL;
-    type: abstract-op; url: #percent-encode; text: percent-encode
-</pre>
 
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 


### PR DESCRIPTION
Fixes #192.

Also fixes a typo we missed in #197, and moves the `<pre class=anchors>` chunk of Bikeshed metadata up to the top, where the rest of the Bikeshed metadata is.

I generated the list of names from the commit log, closed and open PRs, closed and open issues, and the HTML Design Principles acks.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/210.html" title="Last updated on Jun 3, 2020, 9:29 PM UTC (09a8edf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/210/ed1631c...09a8edf.html" title="Last updated on Jun 3, 2020, 9:29 PM UTC (09a8edf)">Diff</a>