### PR TITLE
Preserving content visibility by default (#172)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -514,19 +514,6 @@ See also:
 
 This section details design principles for features which are exposed via CSS.
 
-<h3 id="css-content-should-be-visible">Content should be readable by default</h3>
-
-Design CSS properties or CSS layout systems (which are typically values of the `display` property), 
-to preserve the content as readable and usable by default.  
-
-<div class="example">
-For example, the default behavior of a layout system should not lead to content being clipped, 
-content overlapping other content, or content being unreachable by scrolling. 
-These things should only happen if CSS features are used that are more explicitly choosing 
-such a behavior (for example, `overflow: hidden` or `left: -40em`). They should not happen by 
-default as a result of something like `display: flex` or `position: relative`.
-</div>
-
 <h3 id="css-property-separation">Separate CSS properties based on what should cascade separately</h3>
 
 Decide which values should be grouped together as CSS properties
@@ -692,6 +679,19 @@ Avoid words like "mode" or "state" in the names of properties,
 since properties are generally setting a mode or state.
 
 See [[#naming-is-hard]] for general (cross-language) advice on naming.
+
+<h3 id="css-content-should-be-visible">Content should be viewable and accessible by default</h3>
+
+Design CSS properties or CSS layout systems (which are typically values of the `display` property), 
+to preserve the content as viewable, accessible and usable by default.  
+
+<div class="example">
+For example, the default behavior of all layout systems in CSS will not lead to content being clipped, 
+content overlapping other content, or content being unreachable by scrolling. 
+These things should only happen if CSS features are used that are more explicitly choosing 
+such a behavior (for example, `overflow: hidden` or `left: -40em`). They should not happen by 
+default as a result of something like `display: flex` or `position: relative`.
+</div>
 
 <h2 id="js">JavaScript Language</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -514,6 +514,19 @@ See also:
 
 This section details design principles for features which are exposed via CSS.
 
+<h3 id="css-content-should-be-visible">Content should be readable by default</h3>
+
+Design CSS properties or CSS layout systems (which are typically values of the `display` property), 
+to preserve the content as readable and usable by default.  
+
+<div class="example">
+For example, the default behavior of a layout system should not lead to content being clipped, 
+content overlapping other content, or content being unreachable by scrolling. 
+These things should only happen if CSS features are used that are more explicitly choosing 
+such a behavior (for example, `overflow: hidden` or `left: -40em`). They should not happen by 
+default as a result of something like `display: flex` or `position: relative`.
+</div>
+
 <h3 id="css-property-separation">Separate CSS properties based on what should cascade separately</h3>
 
 Decide which values should be grouped together as CSS properties


### PR DESCRIPTION
Addresses https://github.com/w3ctag/design-principles/issues/172


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/240.html" title="Last updated on Jan 27, 2021, 1:50 AM UTC (c61c0ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/240/a264592...c61c0ff.html" title="Last updated on Jan 27, 2021, 1:50 AM UTC (c61c0ff)">Diff</a>