### PR TITLE
Force 'line-height' reference to css-inline-3 to fix intermittent link error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,6 +27,7 @@ spec:selectors-4; type:selector; text::hover
 spec:css-cascade-5; type:dfn; text:inherit
 spec:html; type:dfn; for:/; text:event loop
 spec:html; type:element-attr; for:a; text:href
+spec:css-inline-3; type:property; text:line-height
 </pre>
 <pre class="anchors">
 url: https://tc39.github.io/ecma262/#sec-error-objects; type: interface; text: Error;


### PR DESCRIPTION
Otherwise it defaults to css2 and then on *some* installations of bikeshed it fails to find the reference


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/design-principles/pull/243.html" title="Last updated on Oct 6, 2020, 12:08 AM UTC (d46dafb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/243/470b2a7...dbaron:d46dafb.html" title="Last updated on Oct 6, 2020, 12:08 AM UTC (d46dafb)">Diff</a>