### PR TITLE
Fix typo in index.bs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1173,7 +1173,7 @@ This guarantees that once the Promise resolves,
 all effects of the algorithm have been applied.
 For example, if an author changes some state
 in reaction to an event which the Promise dispatches,
-they can be sure that all of the state is consistentif the Promise is resolved.
+they can be sure that all of the state is consistent if the Promise is resolved.
 
 <h3 id="dont-invent-event-like">Don’t invent your own event listener-like infrastructure</h3>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pwnall/design-principles/pull/248.html" title="Last updated on Oct 11, 2020, 9:26 PM UTC (10a7218)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/248/665ca0e...pwnall:10a7218.html" title="Last updated on Oct 11, 2020, 9:26 PM UTC (10a7218)">Diff</a>