### PR TITLE
Remove workarounds for reference issues.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,7 +27,6 @@ spec:selectors-4; type:selector; text::hover
 spec:css-cascade-5; type:dfn; text:inherit
 spec:html; type:dfn; for:/; text:event loop
 spec:html; type:element-attr; for:a; text:href
-spec:css-inline-3; type:property; text:line-height
 spec:dom; type:dfn; text:aborted flag
 spec:dom; type:method; for:Document; text:getElementsByTagName(qualifiedName)
 </pre>
@@ -44,7 +43,6 @@ url: https://wicg.github.io/ResizeObserver/;
     type: interface; text: ResizeObserver; url: #resizeobserver
 url: https://dom.spec.whatwg.org/#ref-for-concept-getelementsbytagname; type: interface; text: getElementsByTagName; for: Document
 url: https://drafts.csswg.org/css-transitions-1/#transitions; type: dfn; text: CSS Transitions
-url: https://html.spec.whatwg.org/multipage/browsers.html#browsing-context; type: dfn; text: browsing context;
 url: https://html.spec.whatwg.org/multipage/offline.html#dom-navigator-online; type: attribute; for: NavigatorOnline; text: onLine;
 </pre>
 <!-- Route around bugs in other specs.


### PR DESCRIPTION
This removes the "browsing context" hack that was added in 470b2a77600eef18dc9f9d5a693131bd5ce522ed (part of that commit) in #242, which is no longer needed because the referencing text was removed in 4f5f94c37726cc00fd264fc7fd3a3d1588f1edf0; the underlying issue whatwg/html#5958 still exists.

It removes the `line-height` hack (added in 8ec8a212d874007cb16f1d94aad85d0db36ba650 in #243) that was needed for unknown reasons and is no longer needed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/design-principles/pull/249.html" title="Last updated on Oct 11, 2020, 11:30 PM UTC (022a23d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/249/e701f0a...dbaron:022a23d.html" title="Last updated on Oct 11, 2020, 11:30 PM UTC (022a23d)">Diff</a>