### PR TITLE
Use Bikeshed syntax for more things. Fixes #48.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,46 +19,46 @@ Boilerplate: feedback-header off
 Link Defaults: html (dfn) queue a task/in parallel/reflect
 </pre>
 <pre class="link-defaults">
-spec:html; type:dfn; for:/;
+spec:css-cascade-5; type:dfn; text:inherit
+spec:dom
+    type:dfn; text:aborted flag
+    type:method; for:Document; text:getElementsByTagName(qualifiedName)
+spec:html; type:dfn; for:/
     text:focus update steps
     text:task queue
-spec:webidl; type:dfn; text:namespace
-spec:selectors-4; type:selector; text::hover
-spec:css-cascade-5; type:dfn; text:inherit
-spec:html; type:dfn; for:/; text:event loop
+    text:event loop
 spec:html; type:element-attr; for:a; text:href
-spec:dom; type:dfn; text:aborted flag
-spec:dom; type:method; for:Document; text:getElementsByTagName(qualifiedName)
+spec:html; type:event; text:resize
+spec:selectors-4; type:selector; text::hover
+spec:webidl; type:dfn; text:namespace
 </pre>
-<pre class="anchors">
-url: https://tc39.github.io/ecma262/#sec-error-objects; type: interface; text: Error;
-url: https://www.w3.org/TR/WebCryptoAPI/#dfn-Crypto; type: interface; text: Crypto
-url: https://www.w3.org/TR/payment-request/#dfn-state; type: dfn; spec: payment-request; text: [[state]];
-url: https://w3c.github.io/touch-events/#idl-def-touchevent; type: interface; text: TouchEvent
-url: https://w3c.github.io/IntersectionObserver/;
-    type: interface; text: IntersectionObserver; url: #intersectionobserver
-    type: interface; text: IntersectionObserverEntry; url: #intersectionobserverentry
-    type: dictionary; text: IntersectionObserverInit; url: #dictdef-intersectionobserverinit
-url: https://wicg.github.io/ResizeObserver/;
-    type: interface; text: ResizeObserver; url: #resizeobserver
-url: https://dom.spec.whatwg.org/#ref-for-concept-getelementsbytagname; type: interface; text: getElementsByTagName; for: Document
-url: https://drafts.csswg.org/css-transitions-1/#transitions; type: dfn; text: CSS Transitions
-</pre>
-<!-- Route around bugs in other specs.
-     https://github.com/whatwg/html/issues/5515
+<!-- Some of these 'anchors' entries are really routing around spec bugs.
      https://github.com/w3c/remote-playback/issues/137
-     https://github.com/whatwg/url/issues/522
+     https://github.com/whatwg/html/issues/5515
      https://github.com/whatwg/html/issues/6053
+     https://github.com/whatwg/url/issues/522
      -->
 <pre class="anchors">
+urlPrefix: https://dom.spec.whatwg.org/; spec: DOM
+    url: #dom-document-getelementsbytagname; type: interface; for: Document; text: getElementsByTagName
+urlPrefix: https://w3c.github.io/DOM-Parsing/; spec: DOM-Parsing
+    url: #dom-innerhtml-innerhtml; type: attribute; for: Element; text: innerHTML
+urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA262
+    url: #sec-bigint-objects; type: interface; text: BigInt
+    url: #sec-date-objects; type: interface; text: Date
+    url: #sec-error-objects; type: interface; text: Error
+    url: #sec-finalization-registry-objects; type: interface; text: FinalizationRegistry
+    url: #sec-number-objects; type: interface; text: Number
+    url: #sec-weak-ref-objects; type: interface; text: WeakRef
 urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
-    text: file; for: input/type; type: attr-value; url: input.html#file-upload-state-%28type=file%29
+    url: offline.html#dom-navigator-online; type: attribute; for: NavigatorOnline; text: onLine;
 urlPrefix: https://w3c.github.io/remote-playback/; spec: REMOTE-PLAYBACK
-    text: RemotePlayback; type:interface; url: #remoteplayback-interface
-    text: remote playback device; type:dfn; url: #dfn-remote-playback-devices
-urlPrefix: https://url.spec.whatwg.org/; spec: URL;
-    type: abstract-op; url: #percent-encode; text: percent-encode
-url: https://html.spec.whatwg.org/multipage/offline.html#dom-navigator-online; type: attribute; for: NavigatorOnline; text: onLine;
+    url: #remoteplayback-interface; type:interface; text: RemotePlayback
+    url: #dfn-remote-playback-devices; type:dfn; text: remote playback device
+urlPrefix: https://url.spec.whatwg.org/; spec: URL
+    url: #percent-encode; type: abstract-op; text: percent-encode
+urlPrefix: https://www.w3.org/TR/payment-request/; spec: payment-request
+    url: #dfn-state; type: dfn; text: [[state]];
 </pre>
 
 <style>
@@ -162,7 +162,7 @@ to resemble trusted user interfaces,
 this makes it more difficult for users to understand what information is trustworthy.
 
 <p class="example">
-For example, JavaScript `alert()` allows a page to show a modal dialog which looks like part of the browser.
+For example, JavaScript {{alert()}} allows a page to show a modal dialog which looks like part of the browser.
 This is often used to attempt to trick users into visiting scam websites.
 If this feature was proposed today, it would probably not proceed.
 </p>
@@ -237,9 +237,9 @@ Features should also be designed so that the easiest way to use them
 maintains flexibility.
 
 <div class="example">
-The <a href="https://www.w3.org/TR/CSS2/visuren.html#block-formatting">`display: block`</a>,
-<a href="https://drafts.csswg.org/css-flexbox-1/#box-model">`display: flex`</a>
-and <a href="https://www.w3.org/TR/css-grid-1/#grid-containers">`display: grid`</a> layout models in CSS
+The 'display: block',
+'display: flex',
+and 'display: grid' layout models in CSS
 all default to placing content within the available space and without overlap,
 so that it works across screen sizes,
 and allows users to choose their own font and font size without causing text to overflow.
@@ -362,7 +362,7 @@ Specification authors can limit most features defined in
 <a href="https://heycam.github.io/webidl/">Web IDL</a>,
 to secure contexts
 by using the
-<code>[<a href="https://w3c.github.io/webappsec-secure-contexts/#integration-idl">SecureContext</a>]</code> extended attribute
+{{SecureContext}} extended attribute
 on interfaces, namespaces, or their members (such as methods and attributes).
 
 However, for some types of API (e.g., dispatching an event),
@@ -370,7 +370,7 @@ limitation to secure contexts should just
 be defined in normative prose in the specification.
 If this is the case,
 consider whether there might be scope for adding a similar mechanism
-to <code>[SecureContext]</code>
+to {{SecureContext}}
 to make this process easier for future API developers.
 </div>
 
@@ -785,7 +785,7 @@ or to produce a new {{HTMLCollection}} each time it's invoked.
 it may depend on the timing of garbage collection.
 In contrast, APIs which are explicitly designed
 to depend on garbage collection,
-like `WeakRef` or `FinalizationGroup`,
+like {{WeakRef}} or {{FinalizationRegistry}},
 set accurate author expectations about
 the interaction with garbage collection.
 
@@ -812,7 +812,7 @@ but it doesn't behave this way,
 you should probably use a method instead.
 
 <div class="example">
-For example, <code highlight="js">offsetTop</code> performs layout,
+For example, {{HTMLElement/offsetTop}} performs layout,
 which can be complex and time-consuming.
 It would have been better if this had been a method like {{Element/getBoundingClientRect()}}.
 </div>
@@ -975,7 +975,7 @@ but this should be considered a design mistake rather than recommended practice.
 
 The API must be designed so that if a parameter is left out,
 the default value used is the same as
-converting `undefined` to the type of the parameter.
+converting {{undefined}} to the type of the parameter.
 For example, if a boolean parameter isn't set,
 it must default to false.
 
@@ -1235,7 +1235,7 @@ only to deliver a notification that a change has already finished happening.
 
 <div class="example">
 When a window is resized,
-an event named <code>[resize](https://drafts.csswg.org/cssom-view/#eventdef-window-resize)</code>
+an event named {{resize}}
 is fired at the `Window` object.
 
 It's not possible to stop the resize from happening by intercepting the event.
@@ -1352,26 +1352,25 @@ If the events are deferred instead:
     once the algorithm completes.
 * any other task may change the object's state
     you should include any state relevant to the event with the deferred event.
-    * This usually involves a new subclass of {{Event}},
+    * <span class="informative">This usually involves a new subclass of {{Event}},
         with new attributes to hold the state.
 
         For example, the {{ProgressEvent}} adds {{ProgressEvent/loaded}},
-        {{ProgressEvent/total}}, etc. attributes to hold the state.
+        {{ProgressEvent/total}}, etc. attributes to hold the state.</span>
 * if different parts of an algorithm need to coordinate,
     you may need to define an explicit state machine (well-defined state transitions)
     to ensure that when a deferred event fires,
     the behavior of inspecting or changing state is well-defined.
 
-    For example, in [[payment-request]],
+    <span class="informative">For example, in [[payment-request]],
     the {{PaymentRequest}}'s [=[[state]]=] internal slot
     explicitly tracks the object's state
-    through its well-defined transitions.
+    through its well-defined transitions.</span>
     * These state transitions often use the guarding technique themselves,
          to ensure the state transitions happen appropriately.
 
          For example, in [[payment-request]]
-         note the guards used around the [=[[state]]=] internal slot,
-         such as in the {{MerchantValidationEvent/complete()}} algorithm.
+         note the guards used around the [=[[state]]=] internal slot.
 * if the deferred event doesn't need extra state,
     or a state machine,
     this probably means that the event is just signalling the completion of the algorithm.
@@ -1587,25 +1586,25 @@ If an API you're designing uses numbers,
 use one of the following [[!WEBIDL]] numeric types,
 unless there is a specific reason not to:
 
-  : <code>unrestricted double</code>
+  : {{unrestricted double}}
   :: Any JavaScript number, including infinities and NaN
 
-  : <code>double</code>
+  : {{double}}
   :: Any JavaScript number, excluding infinities and NaN
 
-  : <code>[EnforceRange] long long</code>
+  : [{{EnforceRange}}] {{long long}}
   :: Any JavaScript number from -2<sup>63</sup> to 2<sup>63</sup>,
      rounded to the nearest integer.
      If a number outside this range is given,
-     the generated bindings will throw a <code highlight="js">TypeError</code>.
+     the generated bindings will throw a {{TypeError}}.
 
-  : <code>[EnforceRange] unsigned long long</code>
+  : [{{EnforceRange}}] {{unsigned long long}}
   :: Any JavaScript number from 0 to 2<sup>64</sup>,
      rounded to the nearest integer.
      If a number outside this range is given,
-     the generated bindings will throw a <code highlight="js">TypeError</code>.
+     the generated bindings will throw a {{TypeError}}.
 
-JavaScript has only one numeric type, `Number`:
+JavaScript has only one numeric type, {{Number}}:
 IEEE 754 double-precision floating point, including ±0, ±Infinity, and NaN.
 [[!WEBIDL]] numeric types represent
 rules for modifying any JavaScript number
@@ -1619,31 +1618,31 @@ you can specify those in your algorithm.
 <div class="note">
 The <a href="https://heycam.github.io/webidl/#es-integer-types">WEBIDL rules</a>
 for converting a JavaScript number to a number with fewer bits,
-such as an `octet` (8 bits, in the range [0, 255]),
+such as an {{octet}} (8 bits, in the range [0, 255]),
 involves taking the modulo of the JavaScript number.
 For example, to convert a JavaScript number value of 300
-to an `octet`,
+to an {{octet}},
 the bindings will first compute 300 modulo 255,
 so the resulting number will be 45,
 which might be surprising.
 
 Instead, you can use
-<code><a href="https://heycam.github.io/webidl/#EnforceRange">[EnforceRange]</a> octet</code>
-to throw a `TypeError` for values outside of the `octet` range,
-or <code><a href="https://heycam.github.io/webidl/#Clamp">[Clamp]</a> octet</code>
+[{{EnforceRange}}] {{octet}}
+to throw a `TypeError` for values outside of the {{octet}} range,
+or [{{Clamp}}] {{octet}}
 to clamp values to the octet range (for example, converting 300 to 255).
 
-This also works for the other shorter types, such as `short` or `long`.
+This also works for the other shorter types, such as {{short}} or {{long}}.
 </div>
 
-<code>bigint</code> should be used only when values greater than 2<sup>53</sup>
+{{bigint}} should be used only when values greater than 2<sup>53</sup>
  or less than -2<sup>53</sup> are expected.
 
- An API should not support both `BigInt` and `Number` simultaneously,
+ An API should not support both {{BigInt}} and {{Number}} simultaneously,
 either by supporting both types via polymorphism,
-or by adding separate, otherwise identical APIs which take `BigInt` and `Number`.
+or by adding separate, otherwise identical APIs which take {{BigInt}} and {{Number}}.
 This risks losing precision through implicit conversions,
-which defeats the purpose of `BigInt`.
+which defeats the purpose of {{BigInt}}.
 <h3 id="idl-string-types">Represent strings appropriately</h3>
 
 <!--
@@ -1701,8 +1700,8 @@ This means that authors don't need to convert values used in one API
 to be used in another API,
 or keep track of which time unit is needed where.
 
-This convention began with <code highlight="js">setTimeout</code> and the
-<code highlight="js">Date</code> API,
+This convention began with {{setTimeout}} and the
+{{Date}} API,
 and has been used since then.
 
 Note: high-resolution time is usually represented as fractional milliseconds
@@ -1716,13 +1715,13 @@ Use {{DOMHighResTimeStamp}} if authors
 must always be able to compare timestamps,
 regardless of the user's time settings.
 
-Don't use the JavaScript <code highlight="js">Date</code> class for representing
+Don't use the JavaScript {{Date}} class for representing
 specific date-time values.
-<code highlight="js">Date</code> objects are mutable (may have their value changed),
+{{Date}} objects are mutable (may have their value changed),
 and there is no way to make them immutable.
 
 <div class="note">
-    For more background on why <code highlight="js">Date</code> must not be used,
+    For more background on why {{Date}} must not be used,
     see the following:
 
     * <a href="https://esdiscuss.org/topic/frozen-date-objects">Frozen date objects?</a> on
@@ -2333,7 +2332,7 @@ prefixed with <code>is</code> to be consistent with the rest of the platform.
 Although they haven't always been uniformly followed, through the history of web platform API
 design, the following rules have emerged:
 
-<table class="data complex">
+<table class="data complex informative">
     <thead>
         <tr>
             <th></th>
@@ -2344,56 +2343,56 @@ design, the following rules have emerged:
     <tr>
         <th>Methods and properties<br>(Web IDL attributes, operations, and dictionary keys)</th>
         <td>Camel case</td>
-        <td><code highlight="js">document.createAttribute()</code><br>
-            <code highlight="js">document.compatMode</code></td>
+        <td>{{Document/createAttribute()}}<br>
+            {{Document/compatMode}}</td>
     </tr>
     <tr>
         <th>Classes and mixins<br>(Web IDL interfaces)</th>
         <td>Pascal case</td>
-        <td><code highlight="js">NamedNodeMap</code><br>
-            <code highlight="js">NonElementParentNode</code></td>
+        <td>{{NamedNodeMap}}<br>
+            {{NonElementParentNode}}</td>
     </tr>
     <tr>
         <th>Initialisms in APIs</th>
         <td>All caps, except when the first word in a method or property</td>
-        <td><code highlight="js">HTMLCollection</code><br>
-            <code highlight="js">element.innerHTML</code><br>
-            <code highlight="js">document.bgColor</code></td>
+        <td>{{HTMLCollection}}<br>
+            {{Element/innerHTML}}<br>
+            {{Document/bgColor}}</td>
     </tr>
     <tr>
         <th>Repeated initialisms in APIs</th>
         <td>Follow the same rule</td>
-        <td><code highlight="js">HTMLHRElement</code><br>
-            <code highlight="js">RTCDTMFSender</code><br>
+        <td>{{HTMLHRElement}}<br>
+            {{RTCDTMFSender}}<br>
     </tr>
     <tr>
         <th>The abbreviation of "identity"</th>
-        <td><code highlight="js">Id</code>, except when the first word in a method or property</td>
-        <td><code highlight="js">node.getElementById()</code><br>
-            <code highlight="js">event.pointerId</code><br>
-            <code highlight="js">credential.id</code></td>
+        <td><code>Id</code>, except when the first word in a method or property</td>
+        <td>{{NonElementParentNode/getElementById()}}<br>
+            {{PointerEvent/pointerId}}<br>
+            {{Credential/id}}</td>
     </tr>
     <tr>
         <th>Enumeration values</th>
         <td>Lowercase, dash-delimited</td>
-        <td><code highlight="js">"no-referrer-when-downgrade"</code></td>
+        <td>{{"no-referrer-when-downgrade"}}</td>
     </tr>
     <tr>
         <th>Events</th>
         <td>Lowercase, concatenated</td>
-        <td><code>autocompleteerror</code><br>
-            <code>languagechange</code></td>
+        <td><code>autocompleteerror}}<br>
+            <code>languagechange}}</td>
     </tr>
     <tr>
         <th>HTML elements and attributes</th>
         <td>Lowercase, concatenated</td>
-        <td><code highlight="html">&lt;figcaption&gt;</code><br>
-            <code highlight="html">&lt;textarea maxlength&gt;</code></td>
+        <td><{figcaption}><br>
+            <{textarea maxlength}></td>
     </tr>
     <tr>
         <th>JSON keys</th>
         <td>Lowercase, underscore-delimited</td>
-        <td><code highlight="js">manifest.short_name</code></td>
+        <td>{{WebAppManifest/short_name}}</td>
     </tr>
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -362,7 +362,7 @@ Specification authors can limit most features defined in
 <a href="https://heycam.github.io/webidl/">Web IDL</a>,
 to secure contexts
 by using the
-{{SecureContext}} extended attribute
+[{{SecureContext}}] extended attribute
 on interfaces, namespaces, or their members (such as methods and attributes).
 
 However, for some types of API (e.g., dispatching an event),
@@ -370,7 +370,7 @@ limitation to secure contexts should just
 be defined in normative prose in the specification.
 If this is the case,
 consider whether there might be scope for adding a similar mechanism
-to {{SecureContext}}
+to [{{SecureContext}}]
 to make this process easier for future API developers.
 </div>
 


### PR DESCRIPTION
Also cleans up Bikeshed's anchors and link-defaults blocks.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/272.html" title="Last updated on Feb 2, 2021, 12:41 AM UTC (b2eb8a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/272/5703024...b2eb8a6.html" title="Last updated on Feb 2, 2021, 12:41 AM UTC (b2eb8a6)">Diff</a>