### PR TITLE
Fix the build.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2446,7 +2446,7 @@ design, the following rules have emerged:
     <tr>
         <th>JSON keys</th>
         <td>Lowercase, underscore-delimited</td>
-        <td>{{WebAppManifest/short_name}}</td>
+        <td>[=manifest/short_name=]</td>
     </tr>
 </table>
 


### PR DESCRIPTION
The build is currently broken for me. This is the error I'm seeing:

```
bikeshed --die-on=warning spec index.bs build/index.html
LINK ERROR: No 'idl' refs found for 'short_name'.
{{WebAppManifest/short_name}}
 ✘  Did not generate, due to fatal errors
make: *** [build/index.html] Error 2
```

This PR fixes it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/304.html" title="Last updated on Apr 16, 2021, 8:59 PM UTC (19a5c83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/304/08f3a98...19a5c83.html" title="Last updated on Apr 16, 2021, 8:59 PM UTC (19a5c83)">Diff</a>