### PR TITLE
Fixing markup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8' 
+        python-version: '3.10' 
     - run: pip install bikeshed
     - run: bikeshed update --skip-manifest
     - run: make

--- a/index.bs
+++ b/index.bs
@@ -792,33 +792,33 @@ maintains [consistency](#consistency) across the language,
 and keeps its vocabulary small.
 
 <div class="example">
-	The same attribute name, <{select/multiple}>,
-	is used on both <{select}>
-	to allow selection of multiple values,
-	as well as on <{input}>
-	to allow entry of multiple values.
+    The same attribute name, <{select/multiple}>,
+    is used on both <{select}>
+    to allow selection of multiple values,
+    as well as on <{input}>
+    to allow entry of multiple values.
 </div>
 
 <div class="example">
-	The <{details/open}> attribute was introduced on the <{details}> element,
-	and then re-used by <{dialog}>.
+    The <{details/open}> attribute was introduced on the <{details}> element,
+    and then re-used by <{dialog}>.
 </div>
 
 If you do re-use an existing attribute,
 try to keep its syntax as close as possible to the syntax of the existing attribute.
 
 <div class="example">
-	The <{label/for}> attribute was introduced on the <{label}> element,
-	for specifying which form element it should be associated with.
-	It was later re-used by <{output}>,
-	for specifying which elements contributed
-	input values to or otherwise affected the calculation.
-	The syntax of the latter is broader:
-	it accepts a space-separated list of ids,
-	whereas the former only accepts one id.
-	However, they both still conform to the same syntax,
-	whereas e.g. if one of them accepted a list of ids,
-	and the other one a selector, that would be an antipattern.
+    The <{label/for}> attribute was introduced on the <{label}> element,
+    for specifying which form element it should be associated with.
+    It was later re-used by <{output}>,
+    for specifying which elements contributed
+    input values to or otherwise affected the calculation.
+    The syntax of the latter is broader:
+    it accepts a space-separated list of ids,
+    whereas the former only accepts one id.
+    However, they both still conform to the same syntax,
+    whereas e.g. if one of them accepted a list of ids,
+    and the other one a selector, that would be an antipattern.
 </div>
 
 The inverse also applies:


### PR DESCRIPTION
tabs -> spaces

Only the last commit is significant here, don't know why other commits are listed


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/405.html" title="Last updated on Dec 7, 2022, 5:00 PM UTC (da6a721)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/405/44c0066...da6a721.html" title="Last updated on Dec 7, 2022, 5:00 PM UTC (da6a721)">Diff</a>