### PR TITLE
Make HTML attribute sections consecutive

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -833,7 +833,7 @@ the functionality you are adding is **not** similar to that of the existing attr
     This is an antipattern; one of these groups of attributes should have had a different name.
 </div>
 
-<h4 id="naming-of-url-attributes">Name URL-containing attributes based on their primary purpose</h3><!-- https://github.com/w3ctag/design-principles/issues/278 -->
+<h4 id="naming-of-url-attributes">Name URL-containing attributes based on their primary purpose</h4><!-- https://github.com/w3ctag/design-principles/issues/278 -->
 
 If the element enables the user to navigate to the URL contained in the attribute, call the attribute `href`, like the <{a}> element's <{a/href}> attribute.
 

--- a/index.bs
+++ b/index.bs
@@ -911,6 +911,26 @@ https://github.com/w3ctag/design-principles/issues/213
 -->
 </div>
 
+<h3 id="html-idl-must-by-synced">Keep attributes in sync</h3>
+
+New content attributes
+should have a corresponding IDL attribute with the same name,
+and the state between the two should be kept synchronized.
+Carving out a synchronized IDL attribute with inconsistent naming
+results in confusion, and should be avoided.
+
+<div class="note">
+This does not hold the other way around.
+A new IDL attribute does not always warrant a content attribute counterpart.
+</div>
+
+<div class="example">
+A counterpattern to this guidance can be found in
+<{input}>'s  <{input/value}>, <{option}>'s <{option/selected}>, and <{input}>'s <{input/checked}>
+where the HTML attributes were never updated
+and the IDL attribute was the single source of truth.
+</div>
+
 <h3 id="avoid-html-parser-blocking">Do not pause the HTML parser</h3>
 
 Ensure that your design does not require HTML parser to pause to handle external resources.
@@ -938,26 +958,6 @@ often result in blank page (or the previous page). The result is a poor user exp
 Consider adding such features only in cases when the overall user experience is improved.
 A canonical example of this is blocking rendering in order to download and process a stylesheet.
 The alternative user experience is a flash of unstyled content, which is undesirable.
-
-<h3 id="html-idl-must-by-synced">Keep attributes in sync</h3>
-
-New content attributes
-should have a corresponding IDL attribute with the same name,
-and the state between the two should be kept synchronized.
-Carving out a synchronized IDL attribute with inconsistent naming
-results in confusion, and should be avoided.
-
-<div class="note">
-This does not hold the other way around.
-A new IDL attribute does not always warrant a content attribute counterpart.
-</div>
-
-<div class="example">
-A counterpattern to this guidance can be found in
-<{input}>'s  <{input/value}>, <{option}>'s <{option/selected}>, and <{input}>'s <{input/checked}>
-where the HTML attributes were never updated
-and the IDL attribute was the single source of truth.
-</div>
 
 <h2 id="css">Cascading Style Sheets (CSS)</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -833,6 +833,20 @@ the functionality you are adding is **not** similar to that of the existing attr
     This is an antipattern; one of these groups of attributes should have had a different name.
 </div>
 
+<h4 id="naming-of-url-attributes">Name URL-containing attributes based on their primary purpose</h3><!-- https://github.com/w3ctag/design-principles/issues/278 -->
+
+If the element enables the user to navigate to the URL contained in the attribute, call the attribute `href`, like the <{a}> element's <{a/href}> attribute.
+
+Note: In hindsight, <{form}>'s <{form/action}> attribute should have been named `href`.
+
+If the element causes the resource at the given URL to be loaded, call the attribute `src`, like the <{img}> element's <{img/src}> attribute or the <{script}> element’s <{script/src}> attribute.
+
+Note: HTML has a number of legacy inconsistencies that should not be emulated, like the way <{link}>'s <{link/href}> attribute might allow for navigation or for resource loading, depending on the value of the element's <{link/rel}> attribute. <!-- TODO: Add an <object data> example after w3ctag/design-principles#370 has been written. -->
+
+If the attribute identifies a URL that is auxilliary to the element's purpose, like <{video}>'s <{video/poster}>, <{q}>'s <{q/cite}>, or <{a}>’s <{a/ping}>, name the attribute after its semantics.
+
+Note: remember that attributes containing URLs should be represented in IDL as {{USVString}}; see [[#idl-string-types]].
+
 <h3 id="html-lists">Use space-separated attributes for short lists of values, separate elements for longer lists</h3>
 <!-- https://github.com/w3ctag/design-principles/issues/277 -->
 
@@ -944,20 +958,6 @@ A counterpattern to this guidance can be found in
 where the HTML attributes were never updated
 and the IDL attribute was the single source of truth.
 </div>
-
-<h3 id="naming-of-url-attributes">Name URL-containing attributes based on their primary purpose</h3><!-- https://github.com/w3ctag/design-principles/issues/278 -->
-
-If the element enables the user to navigate to the URL contained in the attribute, call the attribute `href`, like the <{a}> element's <{a/href}> attribute.
-
-Note: In hindsight, <{form}>'s <{form/action}> attribute should have been named `href`.
-
-If the element causes the resource at the given URL to be loaded, call the attribute `src`, like the <{img}> element's <{img/src}> attribute or the <{script}> element’s <{script/src}> attribute.
-
-Note: HTML has a number of legacy inconsistencies that should not be emulated, like the way <{link}>'s <{link/href}> attribute might allow for navigation or for resource loading, depending on the value of the element's <{link/rel}> attribute. <!-- TODO: Add an <object data> example after w3ctag/design-principles#370 has been written. -->
-
-If the attribute identifies a URL that is auxilliary to the element's purpose, like <{video}>'s <{video/poster}>, <{q}>'s <{q/cite}>, or <{a}>’s <{a/ping}>, name the attribute after its semantics.
-
-Note: remember that attributes containing URLs should be represented in IDL as {{USVString}}; see [[#idl-string-types]].
 
 <h2 id="css">Cascading Style Sheets (CSS)</h2>
 


### PR DESCRIPTION
```diff
 3 HTML
  3.1 Re-use attribute names (only) for similar functionality
+  3.1.1 Name URL-containing attributes based on their primary purpose
  3.2 Use space-separated attributes for short lists of values, separate elements for longer lists
+ 3.3 Keep attributes in sync
- 3.3 Do not pause the HTML parser
- 3.4 Avoid features that block rendering
+ 3.4 Do not pause the HTML parser
+ 3.5 Avoid features that block rendering
- 3.5 Keep attributes in sync
- 3.6 Name URL-containing attributes based on their primary purpose
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gibson042/design-principles/pull/412.html" title="Last updated on Dec 28, 2022, 5:55 PM UTC (b01e6ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/412/69b2ff0...gibson042:b01e6ce.html" title="Last updated on Dec 28, 2022, 5:55 PM UTC (b01e6ce)">Diff</a>