### PR TITLE
Clarify that "id" abbreviates "identifier"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3034,7 +3034,7 @@ design, the following rules have emerged:
             {{RTCDTMFSender}}<br>
     </tr>
     <tr>
-        <th>The abbreviation of "identity"</th>
+        <th>The abbreviation of "identity"/"identifier"</th>
         <td><code>Id</code>, except when the first word in a method or property</td>
         <td>{{NonElementParentNode/getElementById()}}<br>
             {{PointerEvent/pointerId}}<br>


### PR DESCRIPTION
All three examples for «[The abbreviation of "identity"](https://w3ctag.github.io/design-principles/#casing-rules)» link to documents that refer to "identi*fier*" rather than "identi*ty*".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gibson042/design-principles/pull/414.html" title="Last updated on Jan 6, 2023, 4:36 PM UTC (1bd0be4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/414/c5e4fea...gibson042:1bd0be4.html" title="Last updated on Jan 6, 2023, 4:36 PM UTC (1bd0be4)">Diff</a>