### PR TITLE
Fix more lint issues

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1394,10 +1394,7 @@ This means:
 - If static, then return a new object each time.
     In which case, this should be be a method.
 
-<h3 id="prefer-dictionaries">
-<a id="prefer-dict-to-bool"><!-- old id --></a>
-Accept optional and/or primitive arguments through dictionaries
-</h3>
+<h3 id="prefer-dictionaries" oldids="prefer-dict-to-bool">Accept optional and/or primitive arguments through dictionaries</h3>
 
 API methods should generally use dictionary arguments
 instead of a series of optional arguments.
@@ -1493,14 +1490,14 @@ unless otherwise required, use the following list types:
 
 See also:
 
-* [[#prefer-dict-to-bool]]
+* [[#prefer-dictionaries]]
 
 <h3 id="naming-optional-parameters">Name optional arguments appropriately</h3>
 
 Name optional arguments to make the default behavior obvious
 without being named negatively.
 
-This applies whether they are provided in a [dictionary](#prefer-dict-to-bool)
+This applies whether they are provided in a [dictionary](#prefer-dictionaries)
 or as [single arguments](#optional-parameters).
 
 <div class="example">
@@ -2453,7 +2450,7 @@ please rigorously **define the order** in which devices will be listed.
 This can reduce interoperability issues,
 and helps to mitigate fingerprinting.
 (Sort order could reveal other information:
-see [[FINGERPRINTING-GUIDANCE#a_standardized_profile]] for more.)
+see [[FINGERPRINTING-GUIDANCE#standardization]] for more.)
 
 Note: While APIs should not
 expose a full list of devices in an [=implementation-defined=] order,

--- a/index.bs
+++ b/index.bs
@@ -1153,7 +1153,7 @@ with no need to keep things generalized.
 
 <div class="example">
 For example,
-the {{CustomElementRegistry/define(name, constructor)|CustomElementRegistry.define()}} method takes a reference to
+the {{CustomElementRegistry/define()|CustomElementRegistry.define()}} method takes a reference to
 a <a href="https://tc39.es/ecma262/#sec-static-semantics-constructormethod">Constructor Method</a>.
 
 This takes advantage of the relatively recent addition of classes to JavaScript,
@@ -1530,7 +1530,7 @@ if appropriate.
 By default, [[!WEBIDL]] interfaces generate "non-constructible" classes:
 trying to create instances of them using `new X()` will throw a {{TypeError}}.
 To make them constructible,
-you can add appropriate [=constructor operation=] to your interface,
+you can add appropriate [[WEBIDL#idl-constructors|constructor operations]] to your interface,
 and defining the algorithm for creating new instances of your class.
 
 This allows JavaScript developers


### PR DESCRIPTION
Some things changed between opening #413 and merging it, and the [latest deploy job](https://github.com/w3ctag/design-principles/actions/runs/4119796701/jobs/7113862049) still has fatal errors.

> ```
> bikeshed --die-on=fatal spec index.bs build/index.html
> LINT: Your document appears to use spaces to indent, but line 795 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 796 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 797 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 798 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 799 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 803 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 804 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 811 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 812 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 813 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 814 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 815 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 816 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 817 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 818 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 819 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 820 starts with tabs.
> LINT: Your document appears to use spaces to indent, but line 821 starts with tabs.
> LINK ERROR: No 'idl' refs found for 'define(name, constructor)'.
> {{CustomElementRegistry/define(name, constructor)|CustomElementRegistry.define()}}
> FATAL ERROR: Autolink <a id="prefer-dict-to-bool" data-link-type="dfn"></a> has no linktext.
>    Did not generate, due to fatal errors
> ```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gibson042/design-principles/pull/418.html" title="Last updated on Feb 9, 2023, 12:50 AM UTC (3e5c577)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/418/6d34b09...gibson042:3e5c577.html" title="Last updated on Feb 9, 2023, 12:50 AM UTC (3e5c577)">Diff</a>