### PR TITLE
Make 6.1 more inclusive of non-Web JS APIs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1252,13 +1252,12 @@ the interaction with garbage collection.
 
 <h2 id="api-surface">JavaScript API Surface Concerns</h2>
 
-<h3 id="attributes-like-data">Attributes should behave like data properties</h3>
+<h3 id="accessors-like-data" oldids="attributes-like-data">Accessors should behave like data properties</h3>
 
-[[!WEBIDL]] attributes should act like simple JavaScript object properties.
+JavaScript accessors (specified as [[!WEBIDL]] attributes with separate getter and setter methods in Web APIs)
+should act like simple JavaScript object properties.
 
-In reality, IDL attributes are implemented as accessor properties
-with separate getter and setter methods.
-To make them act like JavaScript object properties:
+This includes:
 
 * Getters must not have any observable side effects.
 * Getters should not perform any complex operations.
@@ -1268,7 +1267,7 @@ To make them act like JavaScript object properties:
     <code highlight="js">obj.attribute === x</code> is true.
     (This may not be possible if some kind of conversion is necessary for `x`.)
 
-If you were thinking about using an attribute,
+If you were thinking about using an accessor,
 but it doesn't behave this way,
 you should probably use a method instead.
 


### PR DESCRIPTION
Per our discussion today

More context in https://github.com/w3ctag/design-principles/issues/436


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/435.html" title="Last updated on Apr 21, 2023, 5:48 AM UTC (536a252)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/435/0559332...536a252.html" title="Last updated on Apr 21, 2023, 5:48 AM UTC (536a252)">Diff</a>