### PR TITLE
Fix link to live-vs-static

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1390,7 +1390,7 @@ a subsequent `obj.attribute === x` should be true.
 e.g., if a normalization or type conversion step is necessary,
 but should be held as a goal for normal code paths.)
 
-The object you want to return may be [live or static](#js-rtc).
+The object you want to return may be [live or static](#live-vs-static).
 This means:
 
 - If live, then return the same object each time,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/design-principles/pull/439.html" title="Last updated on May 8, 2023, 4:09 PM UTC (af46d7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/439/0559332...jan-ivar:af46d7f.html" title="Last updated on May 8, 2023, 4:09 PM UTC (af46d7f)">Diff</a>