### PR TITLE
More detail on why events should fire before promises

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1477,7 +1477,7 @@ make that argument optional and specify the default value.
 
 <div class="example">
 {{EventTarget/addEventListener()}} takes an optional boolean `useCapture` argument.
-Thie defaults to `false`, meaning that
+This defaults to `false`, meaning that
 the event should be dispatched to the listener in the bubbling phase by default.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1805,7 +1805,7 @@ If a Promise-based asynchronous algorithm dispatches events,
 it should dispatch them before the Promise resolves,
 rather than after.
 
-When a promise is resolved, a microtask is queued to run its reaction callbacks.
+When a promise is resolved, a <a href=https://html.spec.whatwg.org/multipage/webappapis.html#microtask>microtask</a> is queued to run its reaction callbacks.
 Microtasks are processed when the JavaScript stack empties.
 <a href=https://dom.spec.whatwg.org/#dispatching-events>Dispatching an event</a> is synchronous, 
 which involves the JavaScript stack emptying between each listener.

--- a/index.bs
+++ b/index.bs
@@ -1807,7 +1807,8 @@ rather than after.
 
 When a promise is resolved, a microtask is queued to run its reaction callbacks.
 Microtasks are processed when the JavaScript stack empties.
-Dispatching an event can involve the JavaScript stack emptying between listeners.
+<a href=https://dom.spec.whatwg.org/#dispatching-events>Dispatching an event</a> is synchronous, 
+which involves the JavaScript stack emptying between each listener.
 As a result, if a promise is resolved before dispatching a related event,
 the promise reaction callbacks will be invoked between the first and second listeners of the event.
 

--- a/index.bs
+++ b/index.bs
@@ -1812,8 +1812,8 @@ which involves the JavaScript stack emptying between each listener.
 As a result, if a promise is resolved before dispatching a related event,
 the promise reaction callbacks will be invoked between the first and second listeners of the event.
 
-Dispatching the event first prevents this interleaving,
-ensuring that all event listeners are invoked before any of the related promise reaction callbacks.
+Dispatching the event first prevents this interleaving.
+All event listeners are then invoked before any promise reaction callbacks.
 
 <h3 id="dont-invent-event-like">Don’t invent your own event listener-like infrastructure</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -1810,7 +1810,8 @@ Microtasks are processed when the JavaScript stack empties.
 <a href=https://dom.spec.whatwg.org/#dispatching-events>Dispatching an event</a> is synchronous, 
 which involves the JavaScript stack emptying between each listener.
 As a result, if a promise is resolved before dispatching a related event,
-the promise reaction callbacks will be invoked between the first and second listeners of the event.
+any microtasks that are scheduled in reaction to a promise 
+will be invoked between the first and second listeners of the event.
 
 Dispatching the event first prevents this interleaving.
 All event listeners are then invoked before any promise reaction callbacks.

--- a/index.bs
+++ b/index.bs
@@ -1477,7 +1477,7 @@ make that argument optional and specify the default value.
 
 <div class="example">
 {{EventTarget/addEventListener()}} takes an optional boolean `useCapture` argument.
-This defaults to `false`, meaning that
+Thie defaults to `false`, meaning that
 the event should be dispatched to the listener in the bubbling phase by default.
 </div>
 
@@ -1799,17 +1799,20 @@ Follow the <a href="https://www.w3.org/2001/tag/doc/promises-guide#one-time-even
 in the <strong><a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing
 Promise-Using Specifications</a></strong> guideline.
 
-<h3 id="promises-and-events">Events should fire before Promises resolve</h3>
+<h3 id="promises-and-events">Events should fire before related Promises resolve</h3>
 
 If a Promise-based asynchronous algorithm dispatches events,
 it should dispatch them before the Promise resolves,
 rather than after.
 
-This guarantees that once the Promise resolves,
-all effects of the algorithm have been applied.
-For example, if an author changes some state
-in reaction to an event which the Promise dispatches,
-they can be sure that all of the state is consistent if the Promise is resolved.
+When a promise is resolved, a microtask is queued to run its reaction callbacks.
+Microtasks are processed when the JavaScript stack empties.
+Dispatching an event can involve the JavaScript stack emptying between listeners.
+As a result, if a promise is resolved before dispatching a related event,
+the promise reaction callbacks will be invoked between the first and second listeners of the event.
+
+Dispatching the event first prevents this interleaving,
+ensuring that all event listeners are invoked before any of the related promise reaction callbacks.
 
 <h3 id="dont-invent-event-like">Don’t invent your own event listener-like infrastructure</h3>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jakearchibald/design-principles/pull/460.html" title="Last updated on Apr 1, 2024, 8:51 PM UTC (7b95818)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/460/7fe598f...jakearchibald:7b95818.html" title="Last updated on Apr 1, 2024, 8:51 PM UTC (7b95818)">Diff</a>