### PR TITLE
Fix some nits

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1885,10 +1885,10 @@ rather than after.
 
 When a promise is resolved, a <a href=https://html.spec.whatwg.org/multipage/webappapis.html#microtask>microtask</a> is queued to run its reaction callbacks.
 Microtasks are processed when the JavaScript stack empties.
-<a href=https://dom.spec.whatwg.org/#dispatching-events>Dispatching an event</a> is synchronous, 
+<a href=https://dom.spec.whatwg.org/#dispatching-events>Dispatching an event</a> is synchronous,
 which involves the JavaScript stack emptying between each listener.
 As a result, if a promise is resolved before dispatching a related event,
-any microtasks that are scheduled in reaction to a promise 
+any microtasks that are scheduled in reaction to a promise
 will be invoked between the first and second listeners of the event.
 
 Dispatching the event first prevents this interleaving.
@@ -3154,7 +3154,7 @@ of a larger, standardized framework.
 
 [[ENCRYPTED-MEDIA]] and [[payment-request]] are both examples of specifications
 which minimize API differences by isolating a non-standard component
-([=Content Decryption Modules=] and [=payment methods=], respectively)
+([Content Decryption Modules](https://w3c.github.io/encrypted-media/#cdm) and [payment methods](https://www.w3.org/TR/payment-method-manifest/), respectively)
 from the rest of the (shared) API surface.
 
 </div>


### PR DESCRIPTION
Bikeshed complained about broken links, so I fixed those. Trailing whitespace is always unnecessary.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/design-principles/pull/489.html" title="Last updated on Apr 4, 2024, 9:47 PM UTC (30c9222)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/489/ff46d8f...martinthomson:30c9222.html" title="Last updated on Apr 4, 2024, 9:47 PM UTC (30c9222)">Diff</a>