### PR TITLE
fix duplicative text in new-features

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -316,7 +316,8 @@ See [[#feature-detect]].
 
 Add new capabilities to the web with consideration of existing functionality and content.
 
-The Web includes many extension points that allow for additions; see for example [[HTML#extensibility]].
+The Web includes many extension points that allow for additions;
+see for example [[HTML#extensibility]].
 
 Before adding items, consider integration with existing, similar capabilities.
 If this leads to a preferred design approach that cannot be implemented by only adding items,

--- a/index.bs
+++ b/index.bs
@@ -316,17 +316,12 @@ See [[#feature-detect]].
 
 Add new capabilities to the web with consideration of existing functionality and content.
 
-The Web includes many extension points that allow for additions;
-see for example [[HTML#extensibility]].
+The Web includes many extension points that allow for additions; see for example [[HTML#extensibility]].
 
 Before adding items, consider integration with existing, similar capabilities.
 If this leads to a preferred design approach that cannot be implemented by only adding items,
 it might still be possible; see [[#removing-features]].
 
-Do not assume that a change or removal is impossible without first checking.
-Before adding items, consider integration with existing, similar capabilities.
-If this leads to a preferred design approach that cannot be implemented by only adding items,
-it might still be possible; see [[#removing-features]].
 Do not assume that a change or removal is impossible without first checking.
 
 <h3 id=removing-features>Remove or change capabilities only once you understand existing usage</h3>


### PR DESCRIPTION
The new features text seemed to have all sorts of duplicate text... not sure why?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/design-principles/pull/494.html" title="Last updated on May 21, 2024, 5:11 AM UTC (009d364)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/494/ca6bfaf...marcoscaceres:009d364.html" title="Last updated on May 21, 2024, 5:11 AM UTC (009d364)">Diff</a>