### PR TITLE
New principle: A Promise represents completion or a value, not a callback (#342)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1884,8 +1884,8 @@ a promise resolution or rejection callback.
 
 Authors tend to expect that any `async` function can be wrapped
 in another that appends synchronous code at the end.
-This might be so that a return value can be examined, such as using try/catch.
-Using `await` or similar wrappers queues a microtask:
+This might be to examine a resolved value or rejection using try/catch.
+But using `await` or similar wrappers queue a microtask:
 <div class="example">
 ```js
 async function fooWrapper() {
@@ -1901,13 +1901,25 @@ async function fooWrapper() {
 ```
 </div>
 
-To support this pattern, a specification that wishes to restrict `bar()` to
-only succeed if called immediately following a promise resolving can
-minimally limit it to the same task, but not the same microtask.
+In general, the settled result from an asynchronous function
+should be usable at any time.
+
+However, there could be cases where APIs might need to restrict
+when a result can be acted on.
+
+In the above example, perhaps the `platform.foo()` function
+establishes state that has real-time dependencies such that calling
+`bar()` is not viable at any future time.
+
+Never limit the viability of acting on a settled result to a microtask,
+as this prevents most forms of code composition.
+
+If possible, set a short timeout interval. Failing that, viability can
+be limited to the same task, but not a single microtask.
 
 <div class="note">
 One case where this came up was the [captureController.setFocusBehavior()](https://w3c.github.io/mediacapture-screen-share/#dom-capturecontroller-setfocusbehavior)
-method, where timing concerns were solved by adding a timeout on top of
+method, where timing concerns were instead solved by adding a timeout on top of
 the requirement of it being called on the same task that resolves the
 `getDisplayMedia()` promise.
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1922,7 +1922,7 @@ be limited to the same task, but not a single microtask.
 One case where this came up was the [captureController.setFocusBehavior()](https://w3c.github.io/mediacapture-screen-share/#dom-capturecontroller-setfocusbehavior)
 method which controls whether a window the user selects to screen-capture
 should immediately be pushed to the front or not. It can be called as late
-as right <em>after</em> the `getDisplayMedia()` promise. This allows
+as right <em>after</em> the resolution of the `getDisplayMedia()` promise. This allows
 applications to make a different decision based on the window the user chose.
 But the application must act right away or this becomes surprising to the user.
 

--- a/index.bs
+++ b/index.bs
@@ -1883,8 +1883,9 @@ Avoid requiring that something needs to happen synchronously within
 a promise resolution or rejection callback.
 
 Authors tend to expect that any `async` function can be wrapped
-in another that appends synchronous code at the end e.g. to inspect state
-using try/catch. But the `await` queues a microtask:
+in another that appends synchronous code at the end.
+This might be so that a return value can be examined, such as using try/catch.
+Using `await` or similar wrappers queues a microtask:
 <div class="example">
 ```js
 async function fooWrapper() {

--- a/index.bs
+++ b/index.bs
@@ -1882,7 +1882,7 @@ For example, if the bytes represent Float32 values, use a {{Float32Array}}.
 Avoid requiring that something needs to happen synchronously within
 a promise resolution or rejection callback.
 
-Authors take for granted that an `async` function can be wrapped
+Authors tend to expect that any `async` function can be wrapped
 in another that appends synchronous code at the end e.g. to inspect state
 using try/catch. But the `await` queues a microtask:
 <div class="example">
@@ -1900,12 +1900,15 @@ async function fooWrapper() {
 ```
 </div>
 
-To not interfere with this pattern, the lowest recommended restriction is "same task".
+To support this pattern, a specification that wishes to restrict `bar()` to
+only succeed if called immediately following a promise resolving can
+minimally limit it to the same task, but not the same microtask.
 
 <div class="note">
 One case where this came up was the [captureController.setFocusBehavior()](https://w3c.github.io/mediacapture-screen-share/#dom-capturecontroller-setfocusbehavior)
-method, where timing concerns were solved by adding an timeout on top of
-the same task requirement.
+method, where timing concerns were solved by adding a timeout on top of
+the requirement of it being called on the same task that resolves the
+`getDisplayMedia()` promise.
 </div>
 
 <h2 id="event-design">Event Design</h2>

--- a/index.bs
+++ b/index.bs
@@ -1877,11 +1877,12 @@ If the bytes in the buffer have a natural intepretation
 as one of the other TypedArray types, provide that instead.
 For example, if the bytes represent Float32 values, use a {{Float32Array}}.
 
-<h3 id="allow-microtask-switches">A Promise represents a value, not a callback</h3>
+<h3 id="allow-microtask-switches">A Promise represents completion or a value, not a callback</h3>
 
 Avoid requiring that something needs to happen synchronously within
 a promise resolution or rejection callback.
 
+This breaks basic assumptions around asynchronous APIs being wrappable.
 Authors tend to expect that any `async` function can be wrapped
 in another that appends synchronous code at the end.
 This might be to examine a resolved value or rejection using try/catch.
@@ -1904,8 +1905,8 @@ async function fooWrapper() {
 In general, the settled result from an asynchronous function
 should be usable at any time.
 
-However, there could be cases where APIs might need to restrict
-when a result can be acted on.
+However, if the result of your API is time sensitive, you might need
+to restrict when it can be acted on.
 
 In the above example, perhaps the `platform.foo()` function
 establishes state that has real-time dependencies such that calling
@@ -1919,9 +1920,14 @@ be limited to the same task, but not a single microtask.
 
 <div class="example">
 One case where this came up was the [captureController.setFocusBehavior()](https://w3c.github.io/mediacapture-screen-share/#dom-capturecontroller-setfocusbehavior)
-method, where timing concerns were instead solved by adding a timeout on top of
-the requirement of it being called on the same task that resolves the
-`getDisplayMedia()` promise.
+method which controls whether a window the user selects to screen-capture
+should immediately be pushed to the front or not. It can be called as late
+as right <em>after</em> the `getDisplayMedia()` promise. This allows
+applications to make a different decision based on the window the user chose.
+But the application must act right away or this becomes surprising to the user.
+
+This solution was to add a timeout on top of the requirement of it being
+called on the same task that resolves the `getDisplayMedia()` promise.
 </div>
 
 <h2 id="event-design">Event Design</h2>

--- a/index.bs
+++ b/index.bs
@@ -1930,6 +1930,9 @@ The solution was to add a timeout on top of the requirement of it being
 called on the same task that resolves the `getDisplayMedia()` promise.
 </div>
 
+If an API depends on setting up temporary conditions then invoking the caller,
+that is a good reason to use a callback rather than a promise.
+
 <h2 id="event-design">Event Design</h2>
 
 <h3 id="one-time-events">Use promises for one time events</h3>

--- a/index.bs
+++ b/index.bs
@@ -1926,7 +1926,7 @@ as right <em>after</em> the `getDisplayMedia()` promise. This allows
 applications to make a different decision based on the window the user chose.
 But the application must act right away or this becomes surprising to the user.
 
-This solution was to add a timeout on top of the requirement of it being
+The solution was to add a timeout on top of the requirement of it being
 called on the same task that resolves the `getDisplayMedia()` promise.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1917,7 +1917,7 @@ as this prevents most forms of code composition.
 If possible, set a short timeout interval. Failing that, viability can
 be limited to the same task, but not a single microtask.
 
-<div class="note">
+<div class="example">
 One case where this came up was the [captureController.setFocusBehavior()](https://w3c.github.io/mediacapture-screen-share/#dom-capturecontroller-setfocusbehavior)
 method, where timing concerns were instead solved by adding a timeout on top of
 the requirement of it being called on the same task that resolves the

--- a/index.bs
+++ b/index.bs
@@ -1877,6 +1877,37 @@ If the bytes in the buffer have a natural intepretation
 as one of the other TypedArray types, provide that instead.
 For example, if the bytes represent Float32 values, use a {{Float32Array}}.
 
+<h3 id="allow-microtask-switches">A Promise represents a value, not a callback</h3>
+
+Avoid requiring that something needs to happen synchronously within
+a promise resolution or rejection callback.
+
+Authors take for granted that an `async` function can be wrapped
+in another that appends synchronous code at the end e.g. to inspect state
+using try/catch. But the `await` queues a microtask:
+<div class="example">
+```js
+async function fooWrapper() {
+  const foo = await platform.foo();
+  console.log("success");
+  return foo;
+}
+
+(async () => {
+  const foo = await fooWrapper();
+  foo.bar(); // on the same task, but not the same microtask that logged "success"
+})();
+```
+</div>
+
+To not interfere with this pattern, the lowest recommended restriction is "same task".
+
+<div class="note">
+One case where this came up was the [captureController.setFocusBehavior()](https://w3c.github.io/mediacapture-screen-share/#dom-capturecontroller-setfocusbehavior)
+method, where timing concerns were solved by adding an timeout on top of
+the same task requirement.
+</div>
+
 <h2 id="event-design">Event Design</h2>
 
 <h3 id="one-time-events">Use promises for one time events</h3>

--- a/index.bs
+++ b/index.bs
@@ -1905,7 +1905,7 @@ async function fooWrapper() {
 In general, the settled result from an asynchronous function
 should be usable at any time.
 
-However, if the result of your API is time sensitive, you might need
+However, if the result of your API is timing sensitive, you might need
 to restrict when it can be acted on.
 
 In the above example, perhaps the `platform.foo()` function


### PR DESCRIPTION
Fixes #342.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#allow-microtask-switches
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/design-principles/pull/496.html#allow-microtask-switches" title="Last updated on Dec 4, 2024, 11:17 AM UTC (8f15631)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/496/55a06e0...jan-ivar:8f15631.html" title="Last updated on Dec 4, 2024, 11:17 AM UTC (8f15631)">Diff</a>