### PR TITLE
adding a note to ensure consistency with  'Defining string' section of [international-spec]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2457,7 +2457,7 @@ which defeats the purpose of {{BigInt}}.
 <h3 id="idl-string-types">Represent strings appropriately</h3>
 <div class="note">
 This section is meant to be mutually consistent with the <a href="https://www.w3.org/TR/international-specs/#char_string">Defining 'string'</a> Section of [[international-specs]].
-Please report any discrepency that may happen as documents evolve.
+Please report any discrepancies that may happen as the documents evolve.
 </div>
 <!--
     This has been discussed in a number of places.

--- a/index.bs
+++ b/index.bs
@@ -2457,7 +2457,7 @@ which defeats the purpose of {{BigInt}}.
 <h3 id="idl-string-types">Represent strings appropriately</h3>
 <div class="note">
 This section is meant to be mutually consistent with
-the [[international-specs#char_string|Defining 'string']] section
+the [[international-specs#char_string|Defining string]] section
 of [[international-specs]].
 Please report any discrepancies that may happen as the documents evolve.
 </div>

--- a/index.bs
+++ b/index.bs
@@ -2456,7 +2456,9 @@ This risks losing precision through implicit conversions,
 which defeats the purpose of {{BigInt}}.
 <h3 id="idl-string-types">Represent strings appropriately</h3>
 <div class="note">
-This section is meant to be mutually consistent with the <a href="https://www.w3.org/TR/international-specs/#char_string">Defining 'string'</a> Section of [[international-specs]].
+This section is meant to be mutually consistent with
+the [[international-specs#char_string|Defining 'string']] section
+of [[international-specs]].
 Please report any discrepancies that may happen as the documents evolve.
 </div>
 <!--

--- a/index.bs
+++ b/index.bs
@@ -2455,7 +2455,10 @@ or by adding separate, otherwise identical APIs which take {{BigInt}} and {{Numb
 This risks losing precision through implicit conversions,
 which defeats the purpose of {{BigInt}}.
 <h3 id="idl-string-types">Represent strings appropriately</h3>
-
+<div class="note">
+This section is meant to be mutually consistent with the <a href="https://www.w3.org/TR/international-specs/#char_string">Defining 'string'</a> Section of [[international-specs]].
+Please report any discrepency that may happen as documents evolve.
+</div>
 <!--
     This has been discussed in a number of places.
     When editing this section,


### PR DESCRIPTION
This is related to #454


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#idl-string-types
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/517.html#idl-string-types" title="Last updated on Dec 4, 2024, 1:32 PM UTC (7908ef2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/517/fbf6370...7908ef2.html" title="Last updated on Dec 4, 2024, 1:32 PM UTC (7908ef2)">Diff</a>