### PR TITLE
Correct bad advice on undefined conversion

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1607,7 +1607,6 @@ element.scrollIntoView(false);
 See also:
 
 * <a href="https://ariya.io/2011/08/hall-of-api-shame-boolean-trap">Hall of API Shame: Boolean Trap</a>.
-* <a href="https://lists.w3.org/Archives/Public/public-script-coord/2013OctDec/0302.html">APIs that have boolean arguments defaulting to true</a>
 * [[#optional-parameters]]
 * [[#naming-optional-parameters]]
 
@@ -1622,15 +1621,16 @@ This defaults to `false`, meaning that
 the event should be dispatched to the listener in the bubbling phase by default.
 </div>
 
-Note: Exceptions have been made for legacy interoperability reasons
-(such as {{XMLHttpRequest}}),
-but this should be considered a design mistake rather than recommended practice.
+For boolean arguments,
+a default value of `false`
+is strongly preferred.
 
-The API must be designed so that if an argument is left out,
-the default value used is the same as
-converting {{undefined}} to the type of the argument.
-For example, if a boolean argument isn't set,
-it must default to false.
+<div class="example">
+The third, optional argument to {{XMLHttpRequest}}
+defaults to `true` as an exception to this rule.
+This is for legacy interoperability reasons,
+not as an example of good design.
+</div>
 
 When deciding between different list data types for your API,
 unless otherwise required, use the following list types:
@@ -1642,6 +1642,7 @@ unless otherwise required, use the following list types:
 See also:
 
 * [[#prefer-dictionaries]]
+* <a href="https://lists.w3.org/Archives/Public/public-script-coord/2013OctDec/0302.html">APIs that have boolean arguments defaulting to true</a>
 
 <h3 id="naming-optional-parameters">Name optional arguments appropriately</h3>
 


### PR DESCRIPTION
As noted in #437, simple advice to treat absence as equivalent to being passed `undefined` is a mistake.  This advice only really applies to Boolean arguments.

We discussed and concluded that string and number arguments have no sensible default that we could recommend.  Booleans do.

Closes #437.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/518.html" title="Last updated on Dec 4, 2024, 9:56 AM UTC (1192e94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/518/6f3fb06...1192e94.html" title="Last updated on Dec 4, 2024, 9:56 AM UTC (1192e94)">Diff</a>