### PR TITLE
Use more semantic references to HTTP RFCs.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3075,8 +3075,8 @@ New MIME types should have a specification and should be registered with the Int
 
 <h3 id="using-http">Consult documentation on best practices when using HTTP</h3>
 
-When using \[HTTP](https://datatracker.ietf.org/doc/html/rfc9110),
-consult [RFC 9205](https://datatracker.ietf.org/doc/html/rfc9205)
+When using [[RFC9110|HTTP]],
+consult [[RFC9205 inline]]
 for advice on correct usage of the protocol.
 
 [Fetch](https://fetch.spec.whatwg.org/) is the way that
@@ -3088,13 +3088,13 @@ Appropriate use of methods, header fields, content types, caching, and other HTT
 might need to be defined.
 
 Recommendations on best practices for HTTP
-can be found in [RFC 9205](https://datatracker.ietf.org/doc/html/rfc9205) and
+can be found in [[RFC9205 inline]] and
 [other HTTP RFCs](https://datatracker.ietf.org/doc/search?name=HTTP&amp;sort=&amp;rfcs=on&amp;by=group&amp;group=httpbis).
 RFC 9205 includes advice on
-[specifying client behavior](https://datatracker.ietf.org/doc/html/rfc9205#section-4.3),
-[defining header fields](https://datatracker.ietf.org/doc/html/rfc9205#section-4.7),
-[use of media types](https://datatracker.ietf.org/doc/html/rfc9205#section-4.8),
-[evolving specifications](https://datatracker.ietf.org/doc/html/rfc9205#section-4.16), and
+[[RFC9205#section-4.3|specifying client behavior]],
+[[RFC9205#section-4.7|defining header fields]],
+[[RFC9205#section-4.8|use of media types]],
+[[RFC9205#section-4.16|evolving specifications]], and
 other advice on how to get the most out of HTTP.
 
 <h3 id="extend-manifests">Extend existing manifest files rather than creating new ones</h3>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#using-http
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/design-principles/pull/534.html#using-http" title="Last updated on Dec 4, 2024, 4:37 PM UTC (bed9eba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/534/e9fd206...jyasskin:bed9eba.html" title="Last updated on Dec 4, 2024, 4:37 PM UTC (bed9eba)">Diff</a>