### PR TITLE
Improve the run-to-completion principle.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1478,7 +1478,10 @@ Data can update synchronously from the result of developer action.
 and is immediately observable.
 </div>
 
-A few kinds of situations justify violating this rule:
+A few kinds of situations justify violating this rule.
+In these cases,
+be sure to [[#attributes-like-data|expose values as methods rather than attributes
+if they might change in the middle of a JS statement]].
 
 * Observing the current time,
     as in {{Date/now|Date.now()}} and {{Performance/now|performance.now()}},
@@ -1488,6 +1491,8 @@ A few kinds of situations justify violating this rule:
     as in the case of the proposed {{isInputPending()}}.
 * States meant to protect users from surprising UI changes,
     like [=transient activation=].
+    Note that {{UserActivation/isActive|navigator.userActivation.isActive}}
+    violates [[#attributes-like-data]] and should not.
 
 <h3 id="js-gc">Don't expose garbage collection</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -47,6 +47,7 @@ spec:webidl
     type:idl; text:long
     type:idl; text:short
     type:interface; text:double
+spec:web-locks; type:interface; text:LockManager
 </pre>
 <pre class='ignored-specs'>
 spec: css21

--- a/index.bs
+++ b/index.bs
@@ -1461,7 +1461,7 @@ During a `while (true)`,
 and after `await`ing an already-resolved `Promise`,
 you *shouldn't* expect things like:
 
-* The DOM to update as a result of the HTML parser loading network content
+* The DOM to update as a result of the HTML parser loading new content from the network
 * {{HTMLImageElement/width|img.width}} to change as a result of loading image data from the network
 * Buttons of a {{Gamepad}} to change state
 * {{Element/scrollTop}} to change, even if scrolling can visually occur
@@ -1492,7 +1492,7 @@ if they might change in the middle of a JS statement]].
 * States meant to protect users from surprising UI changes,
     like [=transient activation=].
     Note that {{UserActivation/isActive|navigator.userActivation.isActive}}
-    violates [[#attributes-like-data]] and should not.
+    violates [[#attributes-like-data|the guidance that recommends a method for this case]].
 
 <h3 id="js-gc">Don't expose garbage collection</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -1437,9 +1437,6 @@ to have bindings in other programming languages.
 
 <h3 id="js-rtc">Preserve run-to-completion semantics</h3>
 
-Don't modify data accessed via JavaScript APIs
-while a JavaScript <a>event loop</a> is running.
-
 A JavaScript Web API is generally a wrapper around
 a feature implemented in a lower-level language,
 such as C++ or Rust.
@@ -1452,18 +1449,45 @@ Because of that, JavaScript authors take for granted
 that the data available to a function won’t change unexpectedly
 while the function is running.
 
-So if a JavaScript Web API exposes some piece of data,
-such as an object property,
-the user agent must not update that data
-while a JavaScript task is running.
-Instead, if the underlying data changes,
-<a>queue a task</a> to modify the exposed version of the data.
+Changes that are not the result of developer action
+and changes that are asynchronously delivered
+should not happen in the middle of other JavaScript,
+including between [=microtasks=].
+Instead, a task should be [[html#queuing-tasks|queued]],
+or they should update as part of [=update the rendering=].
 
 <div class="example">
-If a JavaScript task has accessed the {{NavigatorOnline/onLine|navigator.onLine}} property,
-and browser's online status changes,
-the property won't be updated until the next task runs.
+During a `while (true)`,
+and after `await`ing an already-resolved `Promise`,
+you *shouldn't* expect things like:
+
+* The DOM to update as a result of the HTML parser loading network content
+* {{HTMLImageElement/width|img.width}} to change as a result of loading image data from the network
+* Buttons of a {{Gamepad}} to change state
+* {{Element/scrollTop}} to change, even if scrolling can visually occur
+
+These things aren't updated by the currently running script,
+so they shouldn't change during the current task.
+
 </div>
+
+Data can update synchronously from the result of developer action.
+
+<div class="example">
+{{ChildNode/remove()|node.remove()}} changes the DOM synchronously
+and is immediately observable.
+</div>
+
+A few kinds of situations justify violating this rule:
+
+* Observing the current time,
+    as in {{Date/now|Date.now()}} and {{Performance/now|performance.now()}},
+    although note that it's also useful to present a consistent task-wide time
+    as in {{AnimationTimeline/currentTime|document.timeline.currentTime}}.
+* Functions meant to help developers interrupt synchronous work,
+    as in the case of the proposed {{isInputPending()}}.
+* States meant to protect users from surprising UI changes,
+    like [=transient activation=].
 
 <h3 id="js-gc">Don't expose garbage collection</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -1442,14 +1442,10 @@ propagate that change to JavaScript between tasks,
 for example by [[html#queuing-tasks|queuing a task]],
 or as part of [=update the rendering=].
 
-A JavaScript Web API is generally a wrapper around
-a feature implemented in a lower-level language,
-such as C++ or Rust.
-Unlike those languages,
-when using JavaScript developers can expect
-that once a piece of code begins executing,
-it will continue executing until it has completed.
-
+Unlike lower-level languages
+such as C++ or Rust,
+JavaScript has historically acted as if
+only one piece of code can execute at once.
 Because of that, JavaScript authors take for granted
 that the data available to a function won’t change unexpectedly
 while the function is running.

--- a/index.bs
+++ b/index.bs
@@ -1457,7 +1457,7 @@ Instead, a task should be [[html#queuing-tasks|queued]],
 or they should update as part of [=update the rendering=].
 
 <div class="example">
-During a `while (true)`,
+During synchronous execution (such as a `while` loop),
 and after `await`ing an already-resolved `Promise`,
 you *shouldn't* expect things like:
 

--- a/index.bs
+++ b/index.bs
@@ -1478,10 +1478,7 @@ Data can update synchronously from the result of developer action.
 and is immediately observable.
 </div>
 
-A few kinds of situations justify violating this rule.
-In these cases,
-be sure to [[#attributes-like-data|expose values as methods rather than attributes
-if they might change in the middle of a JS statement]].
+A few kinds of situations justify violating this rule:
 
 * Observing the current time,
     as in {{Date/now|Date.now()}} and {{Performance/now|performance.now()}},

--- a/index.bs
+++ b/index.bs
@@ -1458,12 +1458,15 @@ including between [=microtasks=].
 <div class="example">
 During synchronous execution (such as a `while` loop),
 and after `await`ing an already-resolved `Promise`,
-you *shouldn't* expect things like:
+developers are *unlikely* to expect things like:
 
 * The DOM to update as a result of the HTML parser loading new content from the network
 * {{HTMLImageElement/width|img.width}} to change as a result of loading image data from the network
 * Buttons of a {{Gamepad}} to change state
 * {{Element/scrollTop}} to change, even if scrolling can visually occur
+* A synchronous method to act differently depending on asynchronous state changes.
+    For example, if {{LockManager}} had synchronous methods,
+    their behavior would depend on concurrent calls in other windows.
 
 These things aren't updated by the currently running script,
 so they shouldn't change during the current task.
@@ -1484,7 +1487,7 @@ A few kinds of situations justify violating this rule:
     although note that it's also useful to present a consistent task-wide time
     as in {{AnimationTimeline/currentTime|document.timeline.currentTime}}.
 * Functions meant to help developers interrupt synchronous work,
-    as in the case of the proposed {{isInputPending()}}.
+    as in the case of {{IdleDeadline/timeRemaining()|IdleDeadline.timeRemaining()}}.
 * States meant to protect users from surprising UI changes,
     like [=transient activation=].
     Note that {{UserActivation/isActive|navigator.userActivation.isActive}}

--- a/index.bs
+++ b/index.bs
@@ -1437,6 +1437,11 @@ to have bindings in other programming languages.
 
 <h3 id="js-rtc">Preserve run-to-completion semantics</h3>
 
+If a change to state originates outside of the JavaScript execution context,
+propagate that change to JavaScript between tasks,
+for example by [[html#queuing-tasks|queuing a task]],
+or as part of [=update the rendering=].
+
 A JavaScript Web API is generally a wrapper around
 a feature implemented in a lower-level language,
 such as C++ or Rust.
@@ -1453,8 +1458,6 @@ Changes that are not the result of developer action
 and changes that are asynchronously delivered
 should not happen in the middle of other JavaScript,
 including between [=microtasks=].
-Instead, a task should be [[html#queuing-tasks|queued]],
-or they should update as part of [=update the rendering=].
 
 <div class="example">
 During synchronous execution (such as a `while` loop),


### PR DESCRIPTION
* "While an event loop is running" wasn't the right period to limit changes.
* We have a list of exceptions to this principle.

This is meant to fix #456; @jakearchibald, can you check it? Thank you for the text!

I think this also supersedes #496. @jan-ivar, have I caught everything you meant to say there?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#js-rtc
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/design-principles/pull/536.html#js-rtc" title="Last updated on Dec 17, 2024, 10:26 PM UTC (21262c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/536/6c1568b...jyasskin:21262c9.html" title="Last updated on Dec 17, 2024, 10:26 PM UTC (21262c9)">Diff</a>