### PR TITLE
Correct grammatical error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -604,16 +604,16 @@ See also:
 Design textual formats that can be easily produced and consumed by people.
 Textual formats also improve [transparency](https://www.w3.org/TR/ethical-web-principles/#transparent).
 
-Favor readability over compactness. 
+Favor readability over compactness.
 File size can be optimized by tooling,
-and tends to become a lower priority over time. 
-When file size is a significantly higher priority, 
+and tends to become a lower priority over time.
+When file size is a significantly higher priority,
 perhaps a textual format is not appropriate.
 
 <div class=example>
-SVG path syntax was designed to be compact, 
+SVG path syntax was designed to be compact,
 with single-letter commands and unlabeled series of coordinates after them.
-At the time, file size was a primary concern, 
+At the time, file size was a primary concern,
 but while the importance of size efficiency has declined over time,
 the cost to human readability has remained the same.
 </div>
@@ -2854,9 +2854,9 @@ the exact lifecycle and data structures of the underlying native APIs.
 When possible, consider flexibility for new hardware.
 
 This means newly proposed APIs should be designed
-with careful consideration on how they are intended to be used
+with regard to how they are intended to be used
 rather than how the underlying hardware, device, or native API
-available today.
+happens to operate today.
 
 <h3 id="hardware-is-scary">Be proactive about safety</h3>
 


### PR DESCRIPTION
The previous form of [this sentence](https://w3ctag.github.io/design-principles/#usecase-oriented-apis) was incomplete in some way.

I've made it shorter and maybe more grammatical.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/design-principles/pull/540.html" title="Last updated on Dec 10, 2024, 2:57 AM UTC (c67e619)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/540/e9fd206...martinthomson:c67e619.html" title="Last updated on Dec 10, 2024, 2:57 AM UTC (c67e619)">Diff</a>