### PR TITLE
Add a section about looking for guidance in other specs.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -544,6 +544,20 @@ i.e. consistency within CSS.
 
 There is also a separate section on <a href="#naming-consistency">naming consistency</a>.
 
+<h3 id="specs-include-guidance">Follow guidance from feature specifications</h3>
+
+The specifications for individual features
+should include guidance for using those features
+consistently across other specifications.
+When using a feature,
+look for that guidance and follow it.
+An incomplete list of such guidance follows:
+
+* [[encoding#specification-hooks|Encoding]]
+* [[fetch#fetch-elsewhere|Fetch]]
+* [[hr-time#sec-tools|Time]]
+* [[url#url-apis-elsewhere|URLs]]
+
 <h3 id="feature-detect">New features should be detectable</h3>
 
 Provide a way for authors to programmatically detect

--- a/index.bs
+++ b/index.bs
@@ -562,6 +562,7 @@ An incomplete list of such guidance follows:
 * [[fetch#fetch-elsewhere|Fetch]]
 * [[hr-time#sec-tools|Time]]
 * [[url#url-apis-elsewhere|URLs]]
+*  [[#using-http]]
 
 <h3 id="feature-detect">New features should be detectable</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -562,7 +562,13 @@ An incomplete list of such guidance follows:
 * [[fetch#fetch-elsewhere|Fetch]]
 * [[hr-time#sec-tools|Time]]
 * [[url#url-apis-elsewhere|URLs]]
-*  [[#using-http]]
+* [[#using-http]]
+
+Consult with the relevant community
+when using their specification.
+This informs that community about new usage
+and creates opportunities for improvements
+to both the using and used specifications.
 
 <h3 id="feature-detect">New features should be detectable</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -546,11 +546,16 @@ There is also a separate section on <a href="#naming-consistency">naming consist
 
 <h3 id="specs-include-guidance">Follow guidance from feature specifications</h3>
 
-The specifications for individual features
-should include guidance for using those features
-consistently across other specifications.
 When using a feature,
-look for that guidance and follow it.
+follow guidance in the specification for that feature.
+
+Specifications for features
+that will be used by other specifications
+should include guidance for using those features.
+This ensures that the feature is used correctly
+and consistently
+throughout the platform.
+
 An incomplete list of such guidance follows:
 
 * [[encoding#specification-hooks|Encoding]]


### PR DESCRIPTION
Fixes #303.

I'm happy to add more links to useful guidance either in this PR or in future ones.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#specs-include-guidance
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/design-principles/pull/542.html#specs-include-guidance" title="Last updated on Dec 17, 2024, 7:22 PM UTC (f980d22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/542/6c1568b...jyasskin:f980d22.html" title="Last updated on Dec 17, 2024, 7:22 PM UTC (f980d22)">Diff</a>