### PR TITLE
Clarify the strings for enums/constants principle

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1998,12 +1998,12 @@ is a request, rather than a guarantee.
 
 Use strings as the values for constants or sets of enumerated values.
 
-Strings are easier for developers to inspect values
+Strings make it easier for developers to inspect values
 and read code that uses those values.
 In JavaScript engines there is no performance benefit
 to using integers instead of strings.
-The [WebIDL enum type](https://webidl.spec.whatwg.org/#idl-enums)
-only permits the use of string values.
+The values of a [WebIDL enum type](https://webidl.spec.whatwg.org/#idl-enums)
+are strings in order to follow this principle.
 
 If you need to express a state which is a combination of properties,
 which might be expressed as a bitmask in another language,

--- a/index.bs
+++ b/index.bs
@@ -1996,17 +1996,31 @@ is a request, rather than a guarantee.
 
 <h3 id="string-constants">Use strings for constants and enums</h3>
 
-If your API needs a constant, or a set of enumerated values,
-use string values.
+Use strings as the values for constants or sets of enumerated values.
 
-Strings are easier for developers to inspect,
-and in JavaScript engines there is no performance benefit
-from using integers instead of strings.
+Strings are easier for developers to inspect values
+and read code that uses those values.
+In JavaScript engines there is no performance benefit
+to using integers instead of strings.
+The [WebIDL enum type](https://webidl.spec.whatwg.org/#idl-enums)
+only permits the use of string values.
 
 If you need to express a state which is a combination of properties,
 which might be expressed as a bitmask in another language,
 use a dictionary object instead.
 This object can be passed around as easily as a single bitmask value.
+
+<div class=example>
+The type of a dedicated Worker is set using an enumerated {{WorkerType}} argument.
+This has two values ("classic" and "module") and might have used a Boolean type instead.
+The use of strings costs nothing and makes code clearer.
+</div>
+
+<div class=example>
+The {{XMLHttpRequest}} {{XMLHttpRequest/readyState}} getter returns an enumerated integer value.
+Code that uses this API therefore requires that readers are familiar with the API to understand it.
+</div>
+
 
 <h3 id="async-by-default">If you need both asynchronous and synchronous methods, synchronous is the exception</h3>
 


### PR DESCRIPTION
Adds examples and tightens things up.

Adds a mention that WebIDL enums only take string values.

One thing that jumped out here was that WebIDL permits the use of numeric/integer constants.  I searched all of the Firefox codebase and I didn't find a single useful instance where a numeric constant made sense.

My operating theory before starting was that there might be some case where developers might be exposed to a number in contexts outside of the web, which might mean that using a numeric constant in the platform made sense.

The one example of that we have is KeyboardEvent.keyCode, which might have made sense if it exposed the Unicode codepoint of a key.  That, however, is solidly deprecated in favor of a much better API.

Every other instance was a bad example.

Closes #427.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/design-principles/pull/555.html" title="Last updated on Mar 4, 2025, 3:37 PM UTC (4d89cad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/555/af2965b...martinthomson:4d89cad.html" title="Last updated on Mar 4, 2025, 3:37 PM UTC (4d89cad)">Diff</a>