### PR TITLE
Fix a linking error on the line-height CSS property.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -26,6 +26,7 @@ Link Defaults: html (dfn) queue a task/in parallel/reflect
 </pre>
 <pre class="link-defaults">
 spec:css-cascade-5; type:dfn; text:inherit
+spec:css2; type: property; text: line-height
 spec:dom
     type:method; for:Document; text:getElementsByTagName(qualifiedName)
     type:method; for:Document; text:createElement(qualifiedName)


### PR DESCRIPTION
This appears to be a Bikeshed bug and can be reverted after that's fixed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/design-principles/pull/558.html" title="Last updated on Feb 26, 2025, 12:29 AM UTC (c61e98f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/558/35a531b...jyasskin:c61e98f.html" title="Last updated on Feb 26, 2025, 12:29 AM UTC (c61e98f)">Diff</a>