### PR TITLE
Add guidance for layout-forcing apis

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1942,11 +1942,18 @@ An API should generally be synchronous if the following rules of thumb apply:
   * The API implementation will not be blocked by a lock, filesystem or network access, for example, inter-process communication.
   * The execution time is short and deterministic.
 
+An API might need to be asynchronous if:
+  * the user agent needs to prompt the user for [permission](#consent),
+  * some information might need to be read from disk,
+    or requested from the network,
+  * the user agent may need to do a significant amount of work on another thread,
+    or in another process, before returning the result.
+  * the user agent requires up-to-date layout before returning the result.
 
-<h3 id="promises">Design asynchronous APIs using Promises</h3>
+<h3 id="promises">Design asynchronous APIs using Promises when possible</h3>
 
 If an API method needs to be asynchronous, use Promises,
-not callback functions.
+not one-time callback functions.
 
 Using Promises consistently across the web platform
 means that APIs are easier to use together,
@@ -1954,16 +1961,14 @@ such as by chaining promises.
 Promise-using code also tends to be easier to understand
 than code using callback functions.
 
-An API might need to be asynchronous if:
-  * the user agent needs to prompt the user for [permission](#consent),
-  * some information might need to be read from disk,
-    or requested from the network,
-  * the user agent may need to do a significant amount of work on another thread,
-    or in another process, before returning the result.
-
 See also:
 
 * <a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>
+
+<div class="Note">
+Promises can't replace callback functions that can be invoked repeatedly.
+Use [[#events-vs-observers|Events or Observers]] instead.
+</div>
 
 <h3 id="aborting">Cancel asynchronous APIs/operations using AbortSignal</h3>
 


### PR DESCRIPTION
Fixes #556

- Explicitly calls out synchronous layout-forcing APIs as inappropriate
- Suggests events or observers when an async API can't use Promises. This (implicitly) covers cases when layout is involved
- Moves the "an API might need to be asynchronous" criteria to the previous section, since it's about when to use async API instead of how to design an async API


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/564.html" title="Last updated on Mar 18, 2025, 12:03 PM UTC (bc16b61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/564/8039864...bc16b61.html" title="Last updated on Mar 18, 2025, 12:03 PM UTC (bc16b61)">Diff</a>