### PR TITLE
fix bikeshed error (disambiguate #blockwidth reference)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3529,7 +3529,7 @@ Sometimes monkey patching is unavoidable (e.g., early in the design phase of a n
     </div>
     <div class="example" id="example-monkeypatch-quote-text-replace-def">
 
-    In terms of CSS2.1 block-level formatting [[CSS2]], the rules for “over-constrained” computations in [[CSS2#blockwidth]] are ignored in favor of alignment as specified here and the used value of the margin properties are therefore not adjusted to correct for the over-constraint.
+    In terms of CSS2.1 block-level formatting [[CSS2]], the rules for “over-constrained” computations in [[CSS2/#blockwidth]] are ignored in favor of alignment as specified here and the used value of the margin properties are therefore not adjusted to correct for the over-constraint.
 
     </div>
     <div class="example" id="example-monkeypatch-quote-text-change-idl">


### PR DESCRIPTION
Disambiguate #blockwidth reference, leading to error in bikeshed


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/566.html" title="Last updated on Mar 25, 2025, 8:27 AM UTC (374f06f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/566/8039864...374f06f.html" title="Last updated on Mar 25, 2025, 8:27 AM UTC (374f06f)">Diff</a>