### PR TITLE
Fix Bikeshed errors.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -36,6 +36,7 @@ spec:webidl
     type:idl; text:short
 </pre>
 <pre class='ignored-specs'>
+spec: epub-34
 spec: svg2
 </pre>
 <pre class="anchors">
@@ -2755,9 +2756,9 @@ than when the capability is granted.
 As more specific information is shared,
 the
 [fingerprinting data](https://www.w3.org/TR/fingerprinting-guidance/)
-available to sites gets larger.
-There are also [[PRIVACY-PRINCIPLES#threats|other potential risks]]
-to user privacy.
+available to sites gets larger,
+as does the chance that some of the information will be
+[[PRIVACY-PRINCIPLES#sensitive-information|sensitive to the particular user]].
 
 If there is no way to design a less powerful API,
 use these guidelines when exposing device information:


### PR DESCRIPTION
Bikeshed noticed that one of our links into the Privacy Principles was
broken, so I reworded the link to be more precise and point at an
existing section.

We deleted the old `#threats` section, which was a copy of the list from https://datatracker.ietf.org/doc/html/rfc6973#section-5. I think the relevant one here, though is just that the information might be sensitive.

This also uses the wrong ID for the target section due to https://github.com/speced/respec/issues/4947 and https://github.com/w3c/reffy/issues/1824. When the respec bug is fixed, this should become `PRIVACY-PRINCIPLES#hl-sensitive-information`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/design-principles/pull/571.html" title="Last updated on Apr 29, 2025, 6:33 PM UTC (aa3fd36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/571/7861814...jyasskin:aa3fd36.html" title="Last updated on Apr 29, 2025, 6:33 PM UTC (aa3fd36)">Diff</a>