### PR TITLE
Replace asking for users for consent with designing for user intent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -160,7 +160,7 @@ If this feature was proposed today, it would probably not proceed.
 <h3 id="user-intent" oldids="consent">Design for user intent</h3>
 
 Use your API design to encourage websites to
-meet user expectations when accessing exceptional capabilities.
+meet user expectations when accessing potentially unsafe capabilities.
 
 In the context of fulfilling a user need,
 a web page may want to make use of a feature


### PR DESCRIPTION
After an [initial discussion](https://github.com/w3c/webappsec/blob/main/meetings/2025/2025-07-16-minutes.md#discouraging-permission-prompts) around [existing Chromium guidance to discourage the use of permission prompts](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/security/no-prompts-please.md) in WebAppSec WG, I was encouraged to propose a change to TAG's design principles doc. This is that change.

My intention is to provide guidance around designing features and APIs in ways that limit the need for asking users questions. When there is a strong and justified need to ask such questions, I want to offer some principles on what needs to be true for users to be able to make good decisions.

H/t to @heisenburger, @mikewest, and @jyasskin for their input on this initial draft.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mharbach/design-principles/pull/584.html" title="Last updated on Oct 21, 2025, 5:03 AM UTC (5ecc9c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/584/444a329...mharbach:5ecc9c0.html" title="Last updated on Oct 21, 2025, 5:03 AM UTC (5ecc9c0)">Diff</a>