### PR TITLE
Clarify when details should go on events vs targets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2595,7 +2595,6 @@ Having state on the {{Event/target}} object can used to determine the current st
 without waiting for the next event.
 This is particularly useful if there's a final state,
 where there will be no further events.
-</div>
 
 It's usually not necessary to create new subclasses of {{Event}},
 but they can be used to provide information relating to how the state change occurred.


### PR DESCRIPTION
I'm proposing this following discussions on `ProgressEvent` in https://github.com/webmachinelearning/translation-api/issues/61.

I wanted to provide reasoning and clarity for this rule, assuming I understand its intent correctly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jakearchibald/design-principles/pull/585.html" title="Last updated on Oct 22, 2025, 10:15 AM UTC (fb77d03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/585/9fc15ba...jakearchibald:fb77d03.html" title="Last updated on Oct 22, 2025, 10:15 AM UTC (fb77d03)">Diff</a>