### PR TITLE
Reference HTTP WG style guide

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -529,8 +529,9 @@ An incomplete list of such guidance follows:
 * [[encoding#specification-hooks|Encoding]]
 * [[fetch#fetch-elsewhere|Fetch]]
 * <span id="using-http">[[RFC9205 inline]]</span>,
-    especially on [[RFC9205#section-4.7|defining header fields]], and
-    [other HTTP RFCs](https://datatracker.ietf.org/doc/search?name=HTTP&amp;sort=&amp;rfcs=on&amp;by=group&amp;group=httpbis)
+    especially on [[RFC9205#section-4.7|defining header fields]],
+    [other HTTP RFCs](https://datatracker.ietf.org/doc/search?name=HTTP&amp;sort=&amp;rfcs=on&amp;by=group&amp;group=httpbis),
+    and the [HTTP Working Group style guide](https://httpwg.org/admin/editors/style-guide)
 * [[hr-time#sec-tools|Time]]
 * [[url#url-apis-elsewhere|URLs]]
 


### PR DESCRIPTION
As this will include a bunch of useful guidance in working with HTTP in specifications that we don't need to maintain.

Closes #422.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/587.html" title="Last updated on Sep 18, 2025, 2:59 AM UTC (b241bf5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/587/c757c94...b241bf5.html" title="Last updated on Sep 18, 2025, 2:59 AM UTC (b241bf5)">Diff</a>