### PR TITLE
Remove notion of asking for consent to reveal AT use

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -801,8 +801,7 @@ See also:
 <h3 id="do-not-expose-use-of-assistive-tech">Don't reveal that assistive technologies are being used</h3>
 
 Make sure that your API doesn't provide a way
-for authors to detect that a user is using assistive technology
-without the user's consent.
+for authors to detect that a user is using assistive technology.
 
 [The web platform must be accessible to people with disabilities.](https://www.w3.org/2001/tag/doc/ethical-web-principles/#allpeople)
 If a site can detect that a user is using an assistive technology,
@@ -811,8 +810,7 @@ that site can deny or restrict the user's access to the services it provides.
 People who make use of assistive technologies
 are often [vulnerable members of society](https://www.w3.org/2001/tag/doc/ethical-web-principles/#noharm);
 their use of assistive technologies is [sensitive information](https://www.w3.org/TR/security-privacy-questionnaire/#sensitive-data) about them.
-If an API provides access to this information
-without the user's [consent](#consent),
+If an API provides access to this information,
 this sensitive information may be revealed to others
 (including [state actors](https://www.w3.org/2001/tag/doc/ethical-web-principles/#expression))
 who may wish them harm.


### PR DESCRIPTION
There was also discussion of linking to WCAG's definition of AT, which is good, but is labelled as '(as used in this document)' and the reason for this (having tried some digital excavation) is not clear, so I will leave that to a separate PR.

Thus this partly addresses #529


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/589.html" title="Last updated on Sep 18, 2025, 3:10 AM UTC (edd57a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/589/c757c94...edd57a9.html" title="Last updated on Sep 18, 2025, 3:10 AM UTC (edd57a9)">Diff</a>