### PR TITLE
Fix example in Keep attributes in sync

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,7 +27,10 @@ Link Defaults: html (dfn) queue a task/in parallel/reflect
 <pre class="link-defaults">
 spec:css-cascade-5; type:dfn; text:inherit
 spec:css2; type: property; text: line-height
-spec:html; type:event; text:resize
+spec:html
+    type:event; text:resize
+    type:attribute; for:HTMLInputElement; text:defaultValue
+    type:attribute; for:HTMLInputElement; text:defaultChecked
 spec:payment-request; type:attribute; for:PaymentRequest; text:[[state]]
 spec:remote-playback; type:dfn; text: remote playback device
 spec:webidl
@@ -1160,8 +1163,7 @@ A new IDL attribute does not always warrant a content attribute counterpart.
 <div class="example">
 A counterpattern to this guidance can be found in
 <{input}>'s  <{input/value}>, <{option}>'s <{option/selected}>, and <{input}>'s <{input/checked}>
-where the HTML attributes were never updated
-and the IDL attribute was the single source of truth.
+where the HTML attributes are reflected under other names, {{defaultValue}}, {{defaultSelected}} and {{defaultChecked}} respectively.
 </div>
 
 <h3 id="naming-of-url-attributes">Name URL-containing attributes based on their primary purpose</h3><!-- https://github.com/w3ctag/design-principles/issues/278 -->

--- a/index.bs
+++ b/index.bs
@@ -1163,7 +1163,8 @@ A new IDL attribute does not always warrant a content attribute counterpart.
 <div class="example">
 A counterpattern to this guidance can be found in
 <{input}>'s  <{input/value}>, <{option}>'s <{option/selected}>, and <{input}>'s <{input/checked}>
-where the HTML attributes are reflected under other names, {{defaultValue}}, {{defaultSelected}} and {{defaultChecked}} respectively.
+where the content attributes are not reflected to IDL attributes with the same names.
+Their IDL attributes are {{defaultValue}}, {{defaultSelected}} and {{defaultChecked}} respectively.
 </div>
 
 <h3 id="naming-of-url-attributes">Name URL-containing attributes based on their primary purpose</h3><!-- https://github.com/w3ctag/design-principles/issues/278 -->


### PR DESCRIPTION
fix example by linking to the proper IDL definitions, fixes #573


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/591.html" title="Last updated on Sep 18, 2025, 3:58 AM UTC (cff1b14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/591/c757c94...cff1b14.html" title="Last updated on Sep 18, 2025, 3:58 AM UTC (cff1b14)">Diff</a>