### PR TITLE
Event names should use the present tense

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2397,6 +2397,58 @@ Similarly, add [=event handler IDL attributes=]
 to {{WindowEventHandlers}} rather than {{Window}}.
 </p>
 
+<h3 id="events-are-for-notification">Name events in a consistent pattern</h3>
+
+New event names should follow the format
+
+[before] + {([noun] + verb) | (noun + preposition)} + [start | end] 
+
+Event names should be centered around a verb in the present tense,
+optionally following a noun as the subject or object of the verb.
+It is also allowed to use a preposition in the place of the verb,
+in which case, however, the noun must be included.
+
+This ensures that "on" + event name makes sense.
+
+<div class="example">
+Most event names use the present tense instead of the past tense.
+For example, {{load}} vs. {{loaded}}, {{resize}} vs. {{resized}}.
+
+Events like {{keydown}}, {{keyup}}, {{mouseover}}
+use a preposition instead of a verb.
+
+{{DOMContentLoaded}} is considered an anti-pattern.
+New events should not be named in this format.
+</div>
+
+<!-- before, after, start, end or nothing -->
+
+duration related: start/end
+animationstart, animationend
+
+intervention needed: before, or nothing since most events
+are dispatched before the actual change
+copy, cut, paste
+beforeunload, beforeinput (due to conflicts with unload, input)
+
+are beforeprint/afterprint antipatterns?
+
+When the event is related to a time-consuming procedure
+where both the start and end are of interest,
+there should be a pair of events
+whose names finish with words "start" and "end".
+
+Examples: animationstart, animationend
+Anipattern: beforeprint, afterprint
+
+When the event is related to a procedure,
+but only the start is of interest
+to provide a means of intervention,
+try not to include any of the words
+"before", "after", "start", "end".
+If this is not possible due to naming conflicts,
+add "before" to the event name.
+
 <h3 id="events-are-for-notification">Use events for notification</h3>
 
 Events shouldn't be used to trigger changes,

--- a/index.bs
+++ b/index.bs
@@ -26,6 +26,7 @@ Link Defaults: html (dfn) queue a task/in parallel/reflect
 </pre>
 <pre class="link-defaults">
 spec:css-cascade-5; type:dfn; text:inherit
+spec:html; type:event; for:Window; text:load
 spec:html; type:event; text:resize
 spec:payment-request; type:attribute; for:PaymentRequest; text:[[state]]
 spec:remote-playback; type:dfn; text: remote playback device

--- a/index.bs
+++ b/index.bs
@@ -2399,13 +2399,12 @@ to {{WindowEventHandlers}} rather than {{Window}}.
 
 <h3 id="name-events-consistently">Name events in a consistent pattern</h3>
 
-When a new event name includes a verb,
-the verb should be in the present tense.
+In new event names, verbs should be in the present tense.
 Do not use the past tense.
 
 <div class="example">
 Almost all event names use the present tense instead of the past tense.
-For example, {{load}} vs. {{loaded}}, {{resize}} vs. {{resized}}.
+For example, {{load}} vs. `loaded`, {{resize}} vs. `resized`.
 
 {{DOMContentLoaded}} is considered an antipattern.
 New events should not follow this format.

--- a/index.bs
+++ b/index.bs
@@ -2566,7 +2566,7 @@ Do not use the past tense.
 
 <div class="example">
 Almost all event names use the present tense instead of the past tense.
-For example, {{load}} instead of <code>loaded</code>,
+For example, {{load}} instead of <code>loaded</code> and
 {{resize}} instead of <code>resized</code>.
 
 {{DOMContentLoaded}} is considered an antipattern.

--- a/index.bs
+++ b/index.bs
@@ -2404,7 +2404,8 @@ Do not use the past tense.
 
 <div class="example">
 Almost all event names use the present tense instead of the past tense.
-For example, {{load}} vs. `loaded`, {{resize}} vs. `resized`.
+For example, {{load}} instead of <code>loaded</code>,
+{{resize}} instead of <code>resized</code>.
 
 {{DOMContentLoaded}} is considered an antipattern.
 New events should not follow this format.

--- a/index.bs
+++ b/index.bs
@@ -2397,57 +2397,23 @@ Similarly, add [=event handler IDL attributes=]
 to {{WindowEventHandlers}} rather than {{Window}}.
 </p>
 
-<h3 id="events-are-for-notification">Name events in a consistent pattern</h3>
+<h3 id="name-events-consistently">Name events in a consistent pattern</h3>
 
-New event names should follow the format
-
-[before] + {([noun] + verb) | (noun + preposition)} + [start | end] 
-
-Event names should be centered around a verb in the present tense,
-optionally following a noun as the subject or object of the verb.
-It is also allowed to use a preposition in the place of the verb,
-in which case, however, the noun must be included.
-
-This ensures that "on" + event name makes sense.
+When a new event name includes a verb,
+the verb should be in the present tense.
+Do not use the past tense.
 
 <div class="example">
-Most event names use the present tense instead of the past tense.
+Almost all event names use the present tense instead of the past tense.
 For example, {{load}} vs. {{loaded}}, {{resize}} vs. {{resized}}.
 
-Events like {{keydown}}, {{keyup}}, {{mouseover}}
-use a preposition instead of a verb.
-
-{{DOMContentLoaded}} is considered an anti-pattern.
-New events should not be named in this format.
+{{DOMContentLoaded}} is considered an antipattern.
+New events should not follow this format.
 </div>
 
-<!-- before, after, start, end or nothing -->
+See also:
 
-duration related: start/end
-animationstart, animationend
-
-intervention needed: before, or nothing since most events
-are dispatched before the actual change
-copy, cut, paste
-beforeunload, beforeinput (due to conflicts with unload, input)
-
-are beforeprint/afterprint antipatterns?
-
-When the event is related to a time-consuming procedure
-where both the start and end are of interest,
-there should be a pair of events
-whose names finish with words "start" and "end".
-
-Examples: animationstart, animationend
-Anipattern: beforeprint, afterprint
-
-When the event is related to a procedure,
-but only the start is of interest
-to provide a means of intervention,
-try not to include any of the words
-"before", "after", "start", "end".
-If this is not possible due to naming conflicts,
-add "before" to the event name.
+* [[#naming-is-hard]].
 
 <h3 id="events-are-for-notification">Use events for notification</h3>
 


### PR DESCRIPTION
Part of #280


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/592.html" title="Last updated on Jun 1, 2026, 5:13 AM UTC (a85c984)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/592/41fee41...a85c984.html" title="Last updated on Jun 1, 2026, 5:13 AM UTC (a85c984)">Diff</a>