### PR TITLE
Clean up link-defaults.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -26,11 +26,7 @@ Link Defaults: html (dfn) queue a task/in parallel/reflect
 </pre>
 <pre class="link-defaults">
 spec:css-cascade-5; type:dfn; text:inherit
-spec:css2; type: property; text: line-height
-spec:html
-    type:event; text:resize
-    type:attribute; for:HTMLInputElement; text:defaultValue
-    type:attribute; for:HTMLInputElement; text:defaultChecked
+spec:html; type:event; text:resize
 spec:payment-request; type:attribute; for:PaymentRequest; text:[[state]]
 spec:remote-playback; type:dfn; text: remote playback device
 spec:webidl
@@ -1163,7 +1159,7 @@ A new IDL attribute does not always warrant a content attribute counterpart.
 A counterpattern to this guidance can be found in
 <{input}>'s  <{input/value}>, <{option}>'s <{option/selected}>, and <{input}>'s <{input/checked}>
 where the content attributes are not reflected to IDL attributes with the same names.
-Their IDL attributes are {{defaultValue}}, {{defaultSelected}} and {{defaultChecked}} respectively.
+Their IDL attributes are {{HTMLInputElement/defaultValue}}, {{defaultSelected}} and {{defaultChecked}} respectively.
 </div>
 
 <h3 id="naming-of-url-attributes">Name URL-containing attributes based on their primary purpose</h3><!-- https://github.com/w3ctag/design-principles/issues/278 -->


### PR DESCRIPTION
I left ones that identify an empty `for` instead of starting the reference with `/`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/design-principles/pull/594.html" title="Last updated on Sep 19, 2025, 7:17 AM UTC (45d83f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/594/98f4a02...jyasskin:45d83f8.html" title="Last updated on Sep 19, 2025, 7:17 AM UTC (45d83f8)">Diff</a>