### PR TITLE
Handle non-fully-active documents

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -929,6 +929,44 @@ it is not always *sufficient*
 to protect users from invasive behaviours.
 [Designing for user intent](#user-intent) and [helping users to make good decisions](#user-decisions) is also important.
 
+<h3 id="handle-destroyed-contexts">Handle non-fully-active documents (and destroyed execution contexts)</h3>
+
+When an <{iframe}> (or similar) is removed or navigated,
+its document stops being [=Document/fully active=]
+and its [=ECMAScript/execution contexts=] can get destroyed.
+However, references to objects from that document
+can remain reachable from other documents
+or from other realms.
+
+Specifications should say what happens both at call time
+and after an operation has begun:
+otherwise background work may keep running after a page is gone,
+UI can hang, and user agents diverge in abort/cleanup behavior.
+
+If the [=relevant global object=]'s [=associated Document=]
+is not [=Document/fully active=] at call time,
+then [=throw=], or return [=a promise rejected with=],
+with {{InvalidStateError}}.
+
+If, after starting an asynchronous operation,
+that [=associated Document=] becomes non-[=Document/fully active=]
+or the [=relevant global object=]'s [=ECMAScript/execution context=] is destroyed,
+abort the operation and reject with {{AbortError}}.
+If the operation presents UI (e.g., a picker, chooser, or prompt),
+dismiss it when the context becomes non-[=Document/fully active=]
+and settle with {{AbortError}}.
+
+When [=queue a task|queueing=] subsequent work
+(e.g., for an event, settling a promise, a time-based operation),
+include an early exit:
+if the [=associated Document=] is not [=Document/fully active=],
+gracefully terminate the [=task=].
+Do not rely on garbage collection to define these semantics.
+
+See also: [[#support-non-fully-active]] for the BFCache case;
+most of the same principles apply to detached iframes
+and other torn-down [=All Execution Contexts/realms=].
+
 <h3 id="support-non-fully-active">Support non-fully active BFCached documents</h3>
 
 Specify how your feature behaves

--- a/index.bs
+++ b/index.bs
@@ -996,6 +996,7 @@ even though BFCache may suspend a document
 rather than tearing it down.
 
 <h3 id="support-non-fully-active">Support non-fully active BFCached documents</h3>
+<h3 id="support-non-fully-active">Support non-fully active BFCached documents</h3>
 
 Specify how your feature behaves
 in non-[=Document/fully active=] BFCached (Back/forward cached) documents if possible.

--- a/index.bs
+++ b/index.bs
@@ -933,10 +933,9 @@ to protect users from invasive behaviours.
 
 Make sure that your API behaves predictably
 when its [=relevant global object=]'s [=associated Document=]
-is no longer [=Document/fully active=]:
-failing fast if the document is already non-[=Document/fully active=]
-and aborting cleanly if it becomes non-[=Document/fully active=]
-mid-operation.
+is no longer [=Document/fully active=].
+Fail fast when the document is already non-[=Document/fully active=]
+and abort cleanly if it becomes non-[=Document/fully active=] mid-operation.
 
 When an <{iframe}> (or similar) is removed or navigated,
 its [=associated Document=] can stop being [=Document/fully active=].
@@ -950,9 +949,10 @@ This situation can arise when browser-mediated UI
 (e.g., authentication, payment, or credential presentation)
 is shown on behalf of an <{iframe}>
 and the <{iframe}> is removed or navigated
-while a user is interacting with it.
+while a user is interacting with that interface.
 
-Specifications should define behavior
+Specifications should define how UI actions
+interact with non-[=Document/fully active=] documents
 both at call time
 and after an operation has begun.
 Doing so helps ensure that background work stops
@@ -984,7 +984,7 @@ settle a promise, or perform time-based processing),
 specifications should include an early-exit check
 at the point the [=task=] runs:
 if the [=associated Document=] is not [=Document/fully active=],
-gracefully terminate the [=task=]
+then gracefully terminate the [=task=]
 without further observable effects.
 Specifications must not rely on garbage collection
 to define these semantics.

--- a/index.bs
+++ b/index.bs
@@ -962,21 +962,21 @@ and that user agents behave consistently.
 
 As general rules:
 
-* If, at call time,
-the [=relevant global object=]'s [=associated Document=]
-is not [=Document/fully active=],
-then the operation must fail immediately:
-either [=throw=] a {{InvalidStateError}} {{DOMException}},
-or return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+  * If, at call time,
+    the [=relevant global object=]'s [=associated Document=]
+    is not [=Document/fully active=],
+    then the operation must fail immediately:
+    either [=throw=] a {{InvalidStateError}} {{DOMException}},
+    or return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 
-* If, after starting an asynchronous operation,
-the [=associated Document=] becomes non-[=Document/fully active=],
-the operation must be aborted
-and failure signaled with {{AbortError}}.
-If the operation presents user-facing UI
-(e.g., a picker, chooser, or prompt),
-dismiss it when the document becomes non-[=Document/fully active=]
-and settle with {{AbortError}}.
+  * If, after starting an asynchronous operation,
+    the [=associated Document=] becomes non-[=Document/fully active=],
+    the operation must be aborted
+    and failure signaled with {{AbortError}}.
+    If the operation presents user-facing UI
+    (e.g., a picker, chooser, or prompt),
+    dismiss it when the document becomes non-[=Document/fully active=]
+    and settle with {{AbortError}}.
 
 When [=queue a task|queueing=] subsequent work
 (for example, to dispatch an event,

--- a/index.bs
+++ b/index.bs
@@ -929,43 +929,71 @@ it is not always *sufficient*
 to protect users from invasive behaviours.
 [Designing for user intent](#user-intent) and [helping users to make good decisions](#user-decisions) is also important.
 
-<h3 id="handle-destroyed-contexts">Handle non-fully-active documents (and destroyed execution contexts)</h3>
+<h3 id="handle-non-fully-active-documents">Handle non-fully-active documents</h3>
+
+Make sure that your API behaves predictably
+when its [=relevant global object=]'s [=associated Document=]
+is no longer [=Document/fully active=]:
+failing fast if the document is already non-[=Document/fully active=]
+and aborting cleanly if it becomes non-[=Document/fully active=]
+mid-operation.
 
 When an <{iframe}> (or similar) is removed or navigated,
-its document stops being [=Document/fully active=]
-and its [=ECMAScript/execution contexts=] can get destroyed.
+its [=associated Document=] can stop being [=Document/fully active=].
+In many cases, user agents will tear down the document’s JavaScript
+[=ECMAScript/execution contexts=] rather than keeping them suspended.
 However, references to objects from that document
 can remain reachable from other documents
-or from other realms.
+or from other [=ECMAScript/realms=].
 
-Specifications should say what happens both at call time
-and after an operation has begun:
-otherwise background work may keep running after a page is gone,
-UI can hang, and user agents diverge in abort/cleanup behavior.
+This situation can arise when browser-mediated UI
+(e.g., authentication, payment, or credential presentation)
+is shown on behalf of an <{iframe}>
+and the <{iframe}> is removed or navigated
+while a user is interacting with it.
 
-If the [=relevant global object=]'s [=associated Document=]
-is not [=Document/fully active=] at call time,
-then [=throw=], or return [=a promise rejected with=],
-with {{InvalidStateError}}.
+Specifications should define behavior
+both at call time
+and after an operation has begun.
+Doing so helps ensure that background work stops
+on non-[=Document/fully active=] documents,
+that user-facing UI is gracefully dismissed,
+and that user agents behave consistently.
 
-If, after starting an asynchronous operation,
-that [=associated Document=] becomes non-[=Document/fully active=]
-or the [=relevant global object=]'s [=ECMAScript/execution context=] is destroyed,
-abort the operation and reject with {{AbortError}}.
-If the operation presents UI (e.g., a picker, chooser, or prompt),
-dismiss it when the context becomes non-[=Document/fully active=]
+As general rules:
+
+* If, at call time,
+the [=relevant global object=]'s [=associated Document=]
+is not [=Document/fully active=],
+then the operation must fail immediately:
+either [=throw=] a {{InvalidStateError}} {{DOMException}},
+or return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+
+* If, after starting an asynchronous operation,
+the [=associated Document=] becomes non-[=Document/fully active=],
+the operation must be aborted
+and failure signaled with {{AbortError}}.
+If the operation presents user-facing UI
+(e.g., a picker, chooser, or prompt),
+dismiss it when the document becomes non-[=Document/fully active=]
 and settle with {{AbortError}}.
 
 When [=queue a task|queueing=] subsequent work
-(e.g., for an event, settling a promise, a time-based operation),
-include an early exit:
+(for example, to dispatch an event,
+settle a promise, or perform time-based processing),
+specifications should include an early-exit check
+at the point the [=task=] runs:
 if the [=associated Document=] is not [=Document/fully active=],
-gracefully terminate the [=task=].
-Do not rely on garbage collection to define these semantics.
+gracefully terminate the [=task=]
+without further observable effects.
+Specifications must not rely on garbage collection
+to define these semantics.
 
-See also: [[#support-non-fully-active]] for the BFCache case;
-most of the same principles apply to detached iframes
-and other torn-down [=All Execution Contexts/realms=].
+See also: [[#support-non-fully-active]] for the BFCache case.
+Many of the same principles apply to detached iframes
+and other documents that have become non-[=Document/fully active=],
+even though BFCache may suspend a document
+rather than tearing it down.
 
 <h3 id="support-non-fully-active">Support non-fully active BFCached documents</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -996,7 +996,6 @@ even though BFCache may suspend a document
 rather than tearing it down.
 
 <h3 id="support-non-fully-active">Support non-fully active BFCached documents</h3>
-<h3 id="support-non-fully-active">Support non-fully active BFCached documents</h3>
 
 Specify how your feature behaves
 in non-[=Document/fully active=] BFCached (Back/forward cached) documents if possible.

--- a/index.bs
+++ b/index.bs
@@ -943,7 +943,7 @@ In many cases, user agents will tear down the document’s JavaScript
 [=ECMAScript/execution contexts=] rather than keeping them suspended.
 However, references to objects from that document
 can remain reachable from other documents
-or from other [=ECMAScript/realms=].
+or from other parts of the user agent.
 
 This situation can arise when browser-mediated UI
 (e.g., authentication, payment, or credential presentation)
@@ -951,7 +951,7 @@ is shown on behalf of an <{iframe}>
 and the <{iframe}> is removed or navigated
 while a user is interacting with that interface.
 
-Specifications should define how UI actions
+Specifications must define how calls and UI actions
 interact with non-[=Document/fully active=] documents
 both at call time
 and after an operation has begun.
@@ -965,9 +965,8 @@ As general rules:
   * If, at call time,
     the [=relevant global object=]'s [=associated Document=]
     is not [=Document/fully active=],
-    then the operation must fail immediately:
-    either [=throw=] a {{InvalidStateError}} {{DOMException}},
-    or return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+    then the operation must fail immediately.
+    We suggest using an {{InvalidStateError}} {{DOMException}}.
 
   * If, after starting an asynchronous operation,
     the [=associated Document=] becomes non-[=Document/fully active=],


### PR DESCRIPTION
This pull request adds new guidance for handling cases where documents or execution contexts are no longer fully active, such as when an iframe is removed or navigated away. The update clarifies how specifications should address the lifecycle and cleanup of asynchronous operations and UI elements associated with destroyed or inactive contexts.

**Guidance for handling destroyed contexts and non-fully-active documents:**

* Added a new section (`#handle-destroyed-contexts`) recommending that specs explicitly define behavior when the associated document is not fully active at call time (e.g., throw or reject with `InvalidStateError`).
* Specified that ongoing async operations should be aborted and rejected with `AbortError` if the context becomes non-fully-active or the execution context is destroyed, and that any UI should be dismissed in such cases.
* Advised that queued tasks should check if the document is still fully active before proceeding, and to avoid relying on garbage collection for cleanup semantics.
* Included cross-references to related guidance for the BFCache and detached iframes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#handle-non-fully-active-documents
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/597.html#handle-non-fully-active-documents" title="Last updated on Jan 27, 2026, 4:16 AM UTC (3ed3057)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/597/6ec7e11...3ed3057.html" title="Last updated on Jan 27, 2026, 4:16 AM UTC (3ed3057)">Diff</a>