### PR TITLE
Avoid abbreviations for strings and enums

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3826,10 +3826,7 @@ Names take meaning from:
 API naming *must* be done in easily readable US English.
 Keep in mind that most web developers aren't native English speakers.
 Whenever possible, names should be chosen that use common vocabulary
-a majority of English speakers are likely to understand when first encountering the name.
-Avoid abbreviations,
-except in cases where an abbreviation is extremely common and easy to understand.
-For example `UIEvent`, where "`UI`" stands for user interface. 
+a majority of English speakers are likely to understand when first encountering the name. 
 
 <div class="example">
 
@@ -3840,6 +3837,9 @@ than `cardinality`.
 </div>
 
 Value readability over brevity.
+Avoid abbreviations,
+except in cases where an abbreviation is extremely common and easy to understand.
+For example `UIEvent`, where "`UI`" stands for user interface.
 Keep in mind, however, that
 the shorter name is often the clearer one.
 For instance,


### PR DESCRIPTION
This pull request makes a minor update to the documentation for using strings as constant values. The change clarifies that abbreviations should be avoided, as they can make code harder to read.

Closes #599


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/600.html" title="Last updated on Oct 21, 2025, 4:51 AM UTC (2c16555)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/600/444a329...2c16555.html" title="Last updated on Oct 21, 2025, 4:51 AM UTC (2c16555)">Diff</a>