### PR TITLE
Un-escape ampersands in a URL to avoid a bikeshed bug.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -595,7 +595,7 @@ An incomplete list of such guidance follows:
 * [[fetch#fetch-elsewhere|Fetch]]
 * <span id="using-http">[[RFC9205 inline]]</span>,
     especially on [[RFC9205#section-4.7|defining header fields]],
-    [other HTTP RFCs](https://datatracker.ietf.org/doc/search?name=HTTP&amp;sort=&amp;rfcs=on&amp;by=group&amp;group=httpbis),
+    [other HTTP RFCs](https://datatracker.ietf.org/doc/search?name=HTTP&sort=&rfcs=on&by=group&group=httpbis),
     and the [HTTP Working Group style guide](https://httpwg.org/admin/editors/style-guide)
 * [[hr-time#sec-tools|Time]]
 * [[url#url-apis-elsewhere|URLs]]


### PR DESCRIPTION
https://github.com/speced/bikeshed/issues/3208
This fix undoes the other half of #520.

Fixes https://github.com/w3ctag/design-principles/actions/runs/19974688077/job/57287839113.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/design-principles/pull/607.html" title="Last updated on Dec 8, 2025, 9:35 PM UTC (a205c28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/607/82069d7...jyasskin:a205c28.html" title="Last updated on Dec 8, 2025, 9:35 PM UTC (a205c28)">Diff</a>