### PR TITLE
chore: fix bikeshed warnings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,7 @@ spec:webidl
 <pre class='ignored-specs'>
 spec: epub-34
 spec: svg2
+spec: mathml-core
 </pre>
 <pre class="anchors">
 urlPrefix: https://www.rfc-editor.org/rfc/rfc9110.html; spec: rfc9110

--- a/index.bs
+++ b/index.bs
@@ -40,8 +40,8 @@ spec:webidl
 </pre>
 <pre class='ignored-specs'>
 spec: epub-34
-spec: svg2
 spec: mathml-core
+spec: svg2
 </pre>
 <pre class="anchors">
 urlPrefix: https://www.rfc-editor.org/rfc/rfc9110.html; spec: rfc9110

--- a/index.bs
+++ b/index.bs
@@ -31,6 +31,8 @@ spec:html
     type:event; text:resize
     type:attribute; for:HTMLInputElement; text:defaultValue
     type:attribute; for:HTMLInputElement; text:defaultChecked
+    type:element; text:a
+    type:element-attr; for:a; text:href
 spec:payment-request; type:attribute; for:PaymentRequest; text:[[state]]
 spec:remote-playback; type:dfn; text: remote playback device
 spec:webidl

--- a/index.bs
+++ b/index.bs
@@ -31,8 +31,6 @@ spec:html
     type:event; text:resize
     type:attribute; for:HTMLInputElement; text:defaultValue
     type:attribute; for:HTMLInputElement; text:defaultChecked
-    type:element; text:a
-    type:element-attr; for:a; text:href
 spec:payment-request; type:attribute; for:PaymentRequest; text:[[state]]
 spec:remote-playback; type:dfn; text: remote playback device
 spec:webidl


### PR DESCRIPTION
Bikeshed was complaining about ambiguous links to the `a` element in HTML.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/pull/610.html" title="Last updated on Jan 27, 2026, 12:30 AM UTC (18d584a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/610/98f4a02...18d584a.html" title="Last updated on Jan 27, 2026, 12:30 AM UTC (18d584a)">Diff</a>