### PR TITLE
Disambiguate when to add global event handlers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2550,7 +2550,7 @@ it's important to continue to define event handler IDL attributes because:
 * they enable feature-detection for the supported events (see [[#feature-detect]])
 
 <p class="note">
-For consistency, if the event needs to be handled by HTML or SVG elements,
+For consistency, if the event needs to be handled by HTML, SVG, or MathML elements,
 add the [=event handler IDL attributes=]
 on the {{GlobalEventHandlers}} interface mixin,
 instead of directly on the relevant element interface(s).

--- a/index.bs
+++ b/index.bs
@@ -2550,7 +2550,7 @@ it's important to continue to define event handler IDL attributes because:
 * they enable feature-detection for the supported events (see [[#feature-detect]])
 
 <p class="note">
-For consistency, if the event needs to be handled by HTML and SVG elements,
+For consistency, if the event needs to be handled by HTML or SVG elements,
 add the [=event handler IDL attributes=]
 on the {{GlobalEventHandlers}} interface mixin,
 instead of directly on the relevant element interface(s).


### PR DESCRIPTION
Fixes https://github.com/w3ctag/design-principles/issues/611. I think when new events are introduced with the intention of being fired at HTML **or** SVG elements, as opposed to just generic non-DOM-associated EventTargets, the guidance is to add them to the [`GlobalEventHandlers`](https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers) mixin.

As https://github.com/w3ctag/design-principles/issues/611 notes, this is the advice I received by Domenic in https://github.com/WICG/fenced-frame/pull/144#discussion_r1560200386, and I think there is slightly ambiguous wording in the design principles that may mistakenly lead people away from this advice when designing new APIs that introduce new events aimed at HTML elements. See https://github.com/w3ctag/design-principles/issues/611#issuecomment-3862411678.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domfarolino/design-principles/pull/612.html" title="Last updated on Feb 11, 2026, 2:14 PM UTC (c206262)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/612/31952d9...domfarolino:c206262.html" title="Last updated on Feb 11, 2026, 2:14 PM UTC (c206262)">Diff</a>