### PR TITLE
Avoid the CSS-value syntax that tries to link to actual values when discouraging names.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1510,7 +1510,8 @@ rather than a form with a grammatical prefix or suffix
 
 The list of values of a property should generally be chosen
 so that new values can be added.
-Avoid values like ''yes'', ''no'', ''true'', ''false'',
+Avoid values like
+<css>yes</css>, <css>no</css>, <css>true</css>, <css>false</css>,
 or things with more complex names that are basically equivalent to them.
 
 Avoid words like "mode" or "state" in the names of properties,


### PR DESCRIPTION
This fixes the Bikeshed warning that `true` and `false` are defined in multiple specs, despite us discouraging them.

@tabatkins, is this the right way to get things to look like CSS names without trying to auto-link them?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/design-principles/pull/624.html" title="Last updated on Sep 11, 2026, 9:41 PM UTC (eb1a615)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/design-principles/624/fd90040...jyasskin:eb1a615.html" title="Last updated on Sep 11, 2026, 9:41 PM UTC (eb1a615)">Diff</a>